### PR TITLE
Add user-only XDG install via make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+BIN_DIR ?= $(HOME)/.local/bin
+CONFIG_DIR ?= $(HOME)/.config/dctl
+DATA_DIR ?= $(HOME)/.local/share/dctl
+SYSTEMD_DIR ?= $(HOME)/.local/share/systemd/user
+
+INSTALL := install
+
+CONFIG_IMAGES := agents python-dev rust-dev zig-dev
+TEMPLATE_DIRS := python rust zig
+
+.PHONY: install uninstall install-systemd uninstall-systemd test lint
+
+install:
+	$(INSTALL) -d "$(BIN_DIR)"
+	$(INSTALL) -m 755 bin/dctl "$(BIN_DIR)/dctl"
+	for image in $(CONFIG_IMAGES); do \
+		$(INSTALL) -d "$(CONFIG_DIR)/$$image"; \
+		$(INSTALL) -m 644 ".config/dctl/$$image/Dockerfile" "$(CONFIG_DIR)/$$image/Dockerfile"; \
+	done
+	$(INSTALL) -d "$(DATA_DIR)/templates"
+	for template in $(TEMPLATE_DIRS); do \
+		$(INSTALL) -d "$(DATA_DIR)/templates/$$template"; \
+		$(INSTALL) -m 644 "templates/$$template/devcontainer.json" "$(DATA_DIR)/templates/$$template/devcontainer.json"; \
+	done
+	$(INSTALL) -m 644 templates/README.md "$(DATA_DIR)/templates/README.md"
+	@printf '\n'
+	@case ":$$PATH:" in *:"$(BIN_DIR)":*) ;; *) \
+		printf '\033[1;33mWARN:\033[0m %s is not in PATH\n' "$(BIN_DIR)"; \
+		printf '      Add to your shell profile: export PATH="%s:$$PATH"\n' "$(BIN_DIR)"; \
+	;; esac
+
+uninstall:
+	rm -f "$(BIN_DIR)/dctl"
+	for image in $(CONFIG_IMAGES); do \
+		rm -f "$(CONFIG_DIR)/$$image/Dockerfile"; \
+		rmdir "$(CONFIG_DIR)/$$image" 2>/dev/null || true; \
+	done
+	rmdir "$(CONFIG_DIR)" 2>/dev/null || true
+	for template in $(TEMPLATE_DIRS); do \
+		rm -f "$(DATA_DIR)/templates/$$template/devcontainer.json"; \
+		rmdir "$(DATA_DIR)/templates/$$template" 2>/dev/null || true; \
+	done
+	rm -f "$(DATA_DIR)/templates/README.md"
+	rmdir "$(DATA_DIR)/templates" 2>/dev/null || true
+	rmdir "$(DATA_DIR)" 2>/dev/null || true
+
+install-systemd:
+	$(INSTALL) -d "$(SYSTEMD_DIR)"
+	sed "s|^ExecStart=.*|ExecStart=$(BIN_DIR)/dctl image build --all|" systemd/dctl-image-build.service \
+		>"$(SYSTEMD_DIR)/dctl-image-build.service"
+	chmod 644 "$(SYSTEMD_DIR)/dctl-image-build.service"
+	$(INSTALL) -m 644 systemd/dctl-image-build.timer "$(SYSTEMD_DIR)/dctl-image-build.timer"
+	@printf '%s\n' "Run: systemctl --user daemon-reload && systemctl --user enable --now dctl-image-build.timer"
+
+uninstall-systemd:
+	systemctl --user disable --now dctl-image-build.timer >/dev/null 2>&1 || true
+	rm -f "$(SYSTEMD_DIR)/dctl-image-build.service"
+	rm -f "$(SYSTEMD_DIR)/dctl-image-build.timer"
+	systemctl --user daemon-reload >/dev/null 2>&1 || true
+
+test:
+	bats tests
+
+lint:
+	shellcheck bin/dctl install.sh uninstall.sh

--- a/README.md
+++ b/README.md
@@ -15,20 +15,40 @@ Three-tier architecture on a shared foundation:
 
 Images provide tooling, not language runtime versions. Project runtime versions stay pinned in project config and are installed at container start.
 
+## Install
+
+```bash
+make install
+
+# Optional: install the weekly rebuild timer
+make install-systemd
+systemctl --user daemon-reload
+systemctl --user enable --now dctl-image-build.timer
+
+# Convenience wrapper
+./install.sh --systemd
+```
+
+`make install` installs:
+
+- `dctl` to `~/.local/bin/dctl`
+- image Dockerfiles to `~/.config/dctl/`
+- devcontainer templates to `~/.local/share/dctl/templates/`
+
+`~/.local/bin` must be in `PATH`. The installer warns if it is missing.
+
 ## Setup
 
 ```bash
-# Deploy package (symlinks Dockerfiles, dctl, and systemd units)
-dots devcontainerctl
-
 # Build all images (requires dotfiles at ~/.dotfiles or $DOT)
 dctl image build --all
 
-# Enable weekly rebuild timer (Friday 18:00)
-systemctl --user enable --now dctl-image-build.timer
-```
+# Inspect available images
+dctl image list
 
-Image definitions now live under `~/.config/dctl/` following the XDG Base Directory spec.
+# Scaffold a project from an installed template
+cp "$HOME/.local/share/dctl/templates/python/devcontainer.json" .devcontainer/devcontainer.json
+```
 
 ## CLI
 
@@ -71,6 +91,18 @@ A systemd user timer rebuilds all images weekly:
 | --- | --- |
 | `dctl-image-build.timer` | Fires Friday 18:00, `Persistent=true` |
 | `dctl-image-build.service` | Runs `dctl image build --all` |
+
+## Uninstall
+
+```bash
+make uninstall
+
+# Remove the user timer if installed
+make uninstall-systemd
+
+# Convenience wrapper
+./uninstall.sh --systemd
+```
 
 ## Further Reading
 

--- a/bin/dctl
+++ b/bin/dctl
@@ -308,7 +308,7 @@ select_image_targets() {
 ensure_image_dir_exists() {
   if [[ ! -d "$IMAGES_DIR" ]]; then
     log "Images directory not found: $IMAGES_DIR"
-    log "Deploy with: dots devcontainerctl"
+    log "Install with: make install"
     return 1
   fi
 }
@@ -377,10 +377,10 @@ cmd_image_build() {
   if [[ ! -d "$IMAGES_DIR" ]]; then
     if [[ "$dry_run" == true ]]; then
       log "Images directory not found: $IMAGES_DIR"
-      log "Deploy with: dots devcontainerctl"
+      log "Install with: make install"
       return 0
     fi
-    printf 'Deploy with: dots devcontainerctl\n' >&2
+    printf 'Install with: make install\n' >&2
     err "Images directory not found: $IMAGES_DIR"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+install_systemd=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --systemd)
+      install_systemd=true
+      shift
+      ;;
+    -h | --help)
+      printf 'Usage: %s [--systemd]\n' "$0"
+      exit 0
+      ;;
+    *)
+      printf 'Usage: %s [--systemd]\n' "$0" >&2
+      exit 1
+      ;;
+  esac
+done
+
+printf 'Installing dctl to %s\n' "${BIN_DIR:-$HOME/.local/bin}"
+make install
+
+if [[ "$install_systemd" == true ]]; then
+  make install-systemd
+fi

--- a/systemd/dctl-image-build.service
+++ b/systemd/dctl-image-build.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Rebuild dctl devcontainer base images
-# Script handles missing docker/images dir with clear error messages
-ConditionPathExists=%h/.config/dctl
 
 [Service]
 Type=oneshot
-ExecStart=%h/.local/bin/dctl image build --all
+ExecStart=dctl image build --all

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -204,3 +204,38 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"Unknown image: unknown"* ]]
 }
+
+@test "make install puts Dockerfiles in CONFIG_DIR and installed dctl uses them" {
+  local bin_dir config_home data_home
+  bin_dir="${TEST_TMPDIR}/bin"
+  config_home="${TEST_TMPDIR}/config-home"
+  data_home="${TEST_TMPDIR}/data-home"
+
+  run make install \
+    BIN_DIR="${bin_dir}" \
+    CONFIG_DIR="${config_home}/dctl" \
+    DATA_DIR="${data_home}/dctl"
+  [ "$status" -eq 0 ]
+
+  [ -f "${config_home}/dctl/agents/Dockerfile" ]
+  [ -f "${data_home}/dctl/templates/python/devcontainer.json" ]
+
+  run env XDG_CONFIG_HOME="${config_home}" HOME="${TEST_TMPDIR}/home" \
+    "${bin_dir}/dctl" image list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"agents"* ]]
+  [[ "$output" == *"python-dev"* ]]
+}
+
+@test "install-systemd writes a service with the selected BIN_DIR" {
+  local systemd_dir bin_dir
+  systemd_dir="${TEST_TMPDIR}/systemd-user"
+  bin_dir="${TEST_TMPDIR}/bin"
+
+  run make install-systemd BIN_DIR="${bin_dir}" SYSTEMD_DIR="${systemd_dir}"
+  [ "$status" -eq 0 ]
+
+  run grep -F "ExecStart=${bin_dir}/dctl image build --all" \
+    "${systemd_dir}/dctl-image-build.service"
+  [ "$status" -eq 0 ]
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+remove_systemd=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --systemd)
+      remove_systemd=true
+      shift
+      ;;
+    -h | --help)
+      printf 'Usage: %s [--systemd]\n' "$0"
+      exit 0
+      ;;
+    *)
+      printf 'Usage: %s [--systemd]\n' "$0" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$remove_systemd" == true ]]; then
+  make uninstall-systemd
+fi
+
+printf 'Uninstalling dctl from %s\n' "${BIN_DIR:-$HOME/.local/bin}"
+make uninstall


### PR DESCRIPTION
Replace stow-based deployment with a standard Makefile installer targeting user home directories only. Installs dctl to ~/.local/bin, image Dockerfiles to ~/.config/dctl, templates to ~/.local/share/dctl, and systemd user units to ~/.local/share/systemd/user.

closes #8 