### PR TITLE
feat: add pre-commit config and route lint/test/check through it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,93 @@
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      # pretty-format-json omitted: repo has no plain .json files (all are JSONC devcontainer.json)
+      - id: check-added-large-files
+        args: ["--maxkb=2048"]
+      - id: detect-private-key
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: no-commit-to-branch
+        args: [--branch, staging, --branch, main, --branch, master]
+
+  - repo: https://github.com/maresb/check-json5
+    rev: v1.0.1
+    hooks:
+      - id: check-json5
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.12.0-2
+    hooks:
+      - id: shfmt
+        args: ["-i", "2", "-ci"]
+
+  # shellharden – auto-quote variables and command substitutions
+  - repo: local
+    hooks:
+      - id: shellharden
+        name: shellharden
+        language: system
+        entry: shellharden --replace
+        types: [shell]
+
+  - repo: https://github.com/openstack/bashate
+    rev: 2.1.1
+    hooks:
+      - id: bashate
+        args: ["-i", "E003,E006", "-e", "E005"]
+        exclude: ^tests/(.*\.bats|test_helper\.bash)$
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.44.0
+    hooks:
+      - id: typos
+        args: ["--write-changes"]
+        exclude: ^\.config/dctl/.*/Dockerfile$
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+        pass_filenames: false
+        stages: [pre-commit]
+
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+        stages: [commit-msg]
+        types_or: [text]
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.13.9
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [pre-push]
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
+  - repo: local
+    hooks:
+      - id: bats-tests
+        name: bats tests
+        language: system
+        entry: bats tests
+        pass_filenames: false
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INSTALL := install
 CONFIG_IMAGES := agents python-dev rust-dev zig-dev
 TEMPLATE_DIRS := python rust zig
 
-.PHONY: install uninstall install-systemd uninstall-systemd test lint
+.PHONY: install uninstall install-systemd uninstall-systemd test lint check
 
 install:
 	$(INSTALL) -d "$(BIN_DIR)"
@@ -59,7 +59,14 @@ uninstall-systemd:
 	systemctl --user daemon-reload >/dev/null 2>&1 || true
 
 test:
-	bats tests
+	pre-commit run bats-tests --all-files
 
 lint:
-	shellcheck bin/dctl install.sh uninstall.sh
+	pre-commit run shellcheck --all-files
+	pre-commit run shfmt --all-files
+	pre-commit run shellharden --all-files
+	pre-commit run bashate --all-files
+	pre-commit run typos --all-files
+
+check:
+	pre-commit run --all-files

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -13,6 +13,7 @@ setup() {
   export XDG_CONFIG_HOME="${TEST_TMPDIR}/xdg-config"
   mkdir -p "${XDG_CONFIG_HOME}/dctl"
   source_dctl_functions
+  # shellcheck disable=SC2329
   workspace_path() { echo "/test/workspace"; }
   unset TERM COLORTERM TERM_PROGRAM TERM_PROGRAM_VERSION 2>/dev/null || true
 }
@@ -158,7 +159,9 @@ teardown() {
 
 @test "collect_term_env includes remote env flags for set vars" {
   local -a args
+  # shellcheck disable=SC2034
   TERM=xterm-kitty
+  # shellcheck disable=SC2034
   COLORTERM=truecolor
   collect_term_env args
   [ "${#args[@]}" -eq 4 ]
@@ -212,7 +215,7 @@ teardown() {
   data_home="${TEST_TMPDIR}/data-home"
 
   run make install \
-    BIN_DIR="${bin_dir}" \
+    BIN_DIR="$bin_dir" \
     CONFIG_DIR="${config_home}/dctl" \
     DATA_DIR="${data_home}/dctl"
   [ "$status" -eq 0 ]
@@ -220,7 +223,7 @@ teardown() {
   [ -f "${config_home}/dctl/agents/Dockerfile" ]
   [ -f "${data_home}/dctl/templates/python/devcontainer.json" ]
 
-  run env XDG_CONFIG_HOME="${config_home}" HOME="${TEST_TMPDIR}/home" \
+  run env XDG_CONFIG_HOME="$config_home" HOME="${TEST_TMPDIR}/home" \
     "${bin_dir}/dctl" image list
   [ "$status" -eq 0 ]
   [[ "$output" == *"agents"* ]]
@@ -232,7 +235,7 @@ teardown() {
   systemd_dir="${TEST_TMPDIR}/systemd-user"
   bin_dir="${TEST_TMPDIR}/bin"
 
-  run make install-systemd BIN_DIR="${bin_dir}" SYSTEMD_DIR="${systemd_dir}"
+  run make install-systemd BIN_DIR="$bin_dir" SYSTEMD_DIR="$systemd_dir"
   [ "$status" -eq 0 ]
 
   run grep -F "ExecStart=${bin_dir}/dctl image build --all" \

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 setup_test_fixtures() {
   TEST_TMPDIR="$(mktemp -d "${BATS_TEST_TMPDIR}/dctl.XXXXXX")"
   export TEST_TMPDIR
@@ -8,7 +6,7 @@ setup_test_fixtures() {
 }
 
 teardown_test_fixtures() {
-  rm -rf "${TEST_TMPDIR}"
+  rm -rf "$TEST_TMPDIR"
 }
 
 enable_mocks() {


### PR DESCRIPTION
- Add .pre-commit-config.yaml with shellcheck-py, shfmt, shellharden, bashate, typos, gitleaks, check-json5, gitlint, commitizen, and meta hooks, plus a local bats-tests hook
- Rework Makefile: make lint/test/check are now pre-commit wrappers
- Fix tests/dctl_test.bats: add shellcheck suppressions, set +x bit
- Fix tests/test_helper.bash: remove incorrect shebang (sourced file)
- Apply shellharden quoting fixes to test files