### PR TITLE
feat(agents): install gh and glab CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Three-tier architecture on a shared foundation:
 
 | Image | Base | What it adds |
 | --- | --- | --- |
-| `devimg/agents` | Debian bookworm-slim | Dev tools, Bun, Rust, mise, Node LTS, neovim, Claude Code, Codex, OpenCode, Gemini CLI |
+| `devimg/agents` | Debian bookworm-slim | Dev tools, Bun, Rust, mise, Node LTS, neovim, gh, glab, Claude Code, Codex, OpenCode, Gemini CLI |
 | `devimg/python-dev` | `devimg/agents` | Poetry via mise (`virtualenvs.in-project = true`) |
 | `devimg/rust-dev` | `devimg/agents` | rustup (`--default-toolchain none`) |
 | `devimg/zig-dev` | `devimg/agents` | anyzig + minisign + zig-zls-init |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,6 +221,8 @@ Foundation layer using Debian bookworm-slim for broad compatibility and package 
 - [Bun](https://bun.com/) as JavaScript runtime for agent CLIs (curl install - no apt package)
 - [Node.js](https://nodejs.org/) LTS via mise (required for bun-installed package shebangs)
 - [mise](https://mise.jdx.dev/) for runtime version management
+- [GitHub CLI (gh)](https://github.com/cli/cli) for GitHub workflows
+- [GitLab CLI (glab)](https://gitlab.com/gitlab-org/cli) for GitLab workflows
 - AI agent CLIs:
   - [Claude Code](https://github.com/anthropics/claude-code) (native installer)
   - [Codex CLI](https://github.com/openai/codex) (OpenAI)
@@ -239,6 +241,13 @@ Native installers are preferred over Homebrew in containers (Homebrew adds ~500M
 | OpenCode | npm (via Bun) | `bun add -g opencode-ai` |
 | Gemini CLI | npm (via Node) | `npm install -g @google/gemini-cli@latest` |
 
+#### Platform CLI Installation Methods
+
+| Tool | Method | Command |
+| ---- | ------ | ------- |
+| gh (GitHub CLI) | Official APT repo | Keyring + `sources.list.d` entry in `images/agents/Dockerfile` |
+| glab (GitLab CLI) | mise (GitLab releases) | `mise use --global gitlab:gitlab-org/cli@latest` |
+
 **Notes**:
 
 - Claude Code: Native installer recommended (auto-updates); npm still supported
@@ -254,8 +263,10 @@ Native installers are preferred over Homebrew in containers (Homebrew adds ~500M
 | Codex CLI | Interactive login (ChatGPT account) on first run |
 | OpenCode | Interactive login (supports multiple providers) |
 | Gemini CLI | Interactive login (Google account) or API key |
+| gh | `gh auth login` (interactive, GitHub account) |
+| glab | `glab auth login` (interactive, GitLab account) |
 
-All agents authenticate interactively on first run. To persist auth across container recreations, mount the agent config directories (see [Pattern 6](#pattern-6-config-with-selective-rw-mounts)).
+All listed CLIs authenticate interactively on first run. To persist auth across container recreations, mount the relevant config directories (see [Pattern 6](#pattern-6-config-with-selective-rw-mounts)).
 
 #### Headless Neovim Bootstrap
 

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -3,13 +3,13 @@
 #
 # Supply chain note: Bun, Claude Code, OpenCode, and the mise
 # refresh are installed via curl-pipe. Codex is installed via Bun (npm-style).
-# Node.js LTS, neovim, Python, fzf, and pre-commit are installed via mise. eza,
-# mise, zoxide, starship, and bottom are
-# installed via cargo-binstall (prebuilt binaries). trash-cli via pipx. Rust
-# toolchain via rustup. Lazy plugins, treesitter parsers, and Mason tools are
-# pre-installed at build time. For stronger guarantees, pin versions and validate
-# checksums. Current approach favors simplicity for personal devcontainers with
-# weekly rebuilds.
+# gh is installed via the official GitHub APT repo. Node.js LTS, neovim,
+# Python, fzf, pre-commit, and glab are installed via mise. eza, mise, zoxide,
+# starship, and bottom are installed via cargo-binstall (prebuilt binaries).
+# trash-cli via pipx. Rust toolchain via rustup. Lazy plugins, treesitter
+# parsers, and Mason tools are pre-installed at build time. For stronger
+# guarantees, pin versions and validate checksums. Current approach favors
+# simplicity for personal devcontainers with weekly rebuilds.
 
 FROM debian:bookworm-slim
 
@@ -88,6 +88,17 @@ RUN git clone --depth=1 https://github.com/lincheney/fzf-tab-completion /usr/sha
     && rm -rf /usr/share/fzf-tab-completion/.git \
     && test -r /usr/share/fzf-tab-completion/bash/fzf-bash-completion.sh
 
+# GitHub CLI (gh): official APT repo tracks latest releases for Debian
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
@@ -134,6 +145,7 @@ RUN curl -fsSL https://mise.run | MISE_INSTALL_PATH="$HOME/.cargo/bin/mise" sh \
     && mise use --global pre-commit@latest \
     && mise use --global go@latest \
     && mise use --global fzf@latest \
+    && mise use --global gitlab:gitlab-org/cli@latest \
     && pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir pipx \
     && python -m pipx install trash-cli \


### PR DESCRIPTION
gh via official GitHub APT repo; glab via mise gitlab backend. Closes #23