### PR TITLE
refactor(dctl): rename claude wrapper references to claude-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ dctl workspace up             # start devcontainer
 dctl workspace reup           # recreate after config/image changes
 dctl workspace shell          # interactive shell
 dctl workspace exec -- pytest # run command in container
-dctl workspace run -- claude  # run via bash -lc
+dctl workspace run -- claude-session  # run via bash -lc
 dctl workspace status         # show containers for this project
 dctl workspace down           # stop and remove
 ```

--- a/bin/dctl
+++ b/bin/dctl
@@ -39,7 +39,7 @@ Examples:
   dctl test
   dctl workspace up
   dctl workspace shell
-  dctl workspace run -- claude
+  dctl workspace run -- claude-session
   dctl image build --all
   dctl image list
 EOF

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1012,8 +1012,8 @@ dctl workspace status
 cd ~/projects/project-a
 
 # Multiple agent sessions
-dctl workspace run -- claude
-dctl workspace run -- claude
+dctl workspace run -- claude-session
+dctl workspace run -- claude-session
 
 # Interactive shell
 dctl workspace shell
@@ -1108,7 +1108,7 @@ UID/GID are baked into the image at build time via `--build-arg USER_UID=$(id -u
 dctl workspace up             # Start current project container
 dctl workspace reup           # Recreate after devcontainer.json/image changes
 dctl workspace shell          # Open interactive bash shell
-dctl workspace run -- claude  # Run command via bash -lc
+dctl workspace run -- claude-session  # Run command via bash -lc
 dctl workspace exec -- id     # Run direct command in container
 dctl workspace status         # Show matching container(s)
 dctl workspace down           # Remove matching container(s)
@@ -1156,7 +1156,7 @@ mise install
 
 # Start container (creates .venv/ via the Python template bootstrap)
 dctl workspace up
-dctl workspace run -- claude  # Interactive login on first run
+dctl workspace run -- claude-session  # Interactive login on first run
 
 # Now open editor - LSP will use container-created .venv/
 nvim .
@@ -1174,7 +1174,7 @@ dctl workspace up
 nvim .
 
 # Terminal 2: agent in container
-dctl workspace run -- claude
+dctl workspace run -- claude-session
 
 # Terminal 3: tests in container
 dctl workspace run -- pytest
@@ -1191,7 +1191,7 @@ dctl workspace down
 
 # Edit .devcontainer/devcontainer.json mounts, then restart
 dctl workspace reup
-dctl workspace run -- claude
+dctl workspace run -- claude-session
 ```
 
 ### Workflow 4: Multi-Directory Workspace Setup
@@ -1220,7 +1220,7 @@ cat > .devcontainer/devcontainer.json << EOF
 EOF
 
 dctl workspace up
-dctl workspace run -- claude  # Interactive login on first run
+dctl workspace run -- claude-session  # Interactive login on first run
 ```
 
 ---
@@ -1427,7 +1427,7 @@ chmod 600 ~/.ssh/deploy_key
 devcontainer exec --workspace-folder . curl -I https://api.anthropic.com
 
 # Re-run interactive login if needed
-devcontainer exec --workspace-folder . bash -lc "claude"
+devcontainer exec --workspace-folder . bash -lc "claude-session"
 ```
 
 ### Find Running Containers

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -47,7 +47,7 @@ Shared auth/editor mounts, `remoteUser`, `init`, `shutdownAction`, container env
 dctl workspace up             # start
 dctl workspace reup           # recreate after devcontainer.json/image changes
 dctl workspace shell          # attach shell
-dctl workspace run -- claude  # run agent command
+dctl workspace run -- claude-session  # run agent command
 dctl workspace run -- pytest  # execute arbitrary command
 dctl workspace status         # show container(s) for current workspace
 dctl workspace down           # stop/remove current workspace container(s)

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -262,8 +262,8 @@ LABEL devcontainer.metadata='[ \
         "type": "bind" \
       }, \
       { \
-        "source": "${localEnv:DOT}/claude/.local/bin/claude", \
-        "target": "${localEnv:HOME}/.local/bin/claude-wrapper", \
+        "source": "${localEnv:DOT}/claude/.local/bin/claude-session", \
+        "target": "${localEnv:HOME}/.local/bin/claude-session", \
         "type": "bind" \
       }, \
       { \

--- a/lib/dctl/workspace.sh
+++ b/lib/dctl/workspace.sh
@@ -144,7 +144,7 @@ cmd_workspace_run() {
   if [[ ${1:-} == "--" ]]; then
     shift
   fi
-  [[ $# -gt 0 ]] || err "run requires a command. Example: dctl workspace run -- claude"
+  [[ $# -gt 0 ]] || err "run requires a command. Example: dctl workspace run -- claude-session"
 
   devcontainer_exec bash -lc "$*"
 }


### PR DESCRIPTION
Update docs, help text, Dockerfile mount, and error messages to use claude-session instead of claude/claude-wrapper, completing the session-isolation wrapper rename in devcontainerctl.