### PR TITLE
feat(workspace): validate dotfiles directory before container creation

### DIFF
--- a/lib/dctl/workspace.sh
+++ b/lib/dctl/workspace.sh
@@ -9,6 +9,12 @@ readonly _DCTL_WORKSPACE_LOADED=1
 # shellcheck source=/dev/null
 source "${DCTL_LIB_DIR}/common.sh"
 
+require_dotfiles_dir() {
+  DOT="${DOT:-${HOME}/.dotfiles}"
+  [[ -d "$DOT" ]] || err "Dotfiles not found at ${DOT} — set DOT= or ensure ~/.dotfiles exists"
+  export DOT
+}
+
 usage_workspace() {
   cat <<'EOF'
 Usage: dctl workspace <command> [options]
@@ -94,6 +100,7 @@ devcontainer_exec() {
 
 cmd_workspace_up() {
   require_cmd devcontainer
+  require_dotfiles_dir
   local args=("$@")
   if [[ ${#args[@]} -gt 0 && ${args[0]} == "--" ]]; then
     args=("${args[@]:1}")
@@ -105,6 +112,7 @@ cmd_workspace_up() {
 
 cmd_workspace_reup() {
   require_cmd devcontainer
+  require_dotfiles_dir
   local args=("$@")
   if [[ ${#args[@]} -gt 0 && ${args[0]} == "--" ]]; then
     args=("${args[@]:1}")

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -397,3 +397,47 @@ teardown() {
     "${systemd_dir}/dctl-image-build.service"
   [ "$status" -eq 0 ]
 }
+
+# Dotfiles validation
+
+@test "workspace up fails early when dotfiles directory is missing" {
+  local missing_home
+  missing_home="${TEST_TMPDIR}/home-no-dotfiles"
+  mkdir -p "$missing_home"
+
+  enable_mocks
+  create_mock devcontainer 0 ""
+
+  unset DOT
+  HOME="$missing_home" run cmd_workspace_up
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Dotfiles not found"* ]]
+  assert_mock_not_called "devcontainer "
+}
+
+@test "workspace reup fails early when dotfiles directory is missing" {
+  local missing_home
+  missing_home="${TEST_TMPDIR}/home-no-dotfiles"
+  mkdir -p "$missing_home"
+
+  enable_mocks
+  create_mock devcontainer 0 ""
+
+  unset DOT
+  HOME="$missing_home" run cmd_workspace_reup
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Dotfiles not found"* ]]
+  assert_mock_not_called "devcontainer "
+}
+
+@test "workspace up calls devcontainer when DOT is valid" {
+  enable_mocks
+  create_mock devcontainer 0 ""
+
+  DOT="${TEST_TMPDIR}/dotfiles"
+  mkdir -p "$DOT"
+
+  run cmd_workspace_up
+  [ "$status" -eq 0 ]
+  assert_mock_called "devcontainer up --workspace-folder ${WORKSPACE_FOLDER}"
+}


### PR DESCRIPTION
Add require_dotfiles_dir preflight check to cmd_workspace_up and cmd_workspace_reup, mirroring the existing build-time validation in image.sh. Gives a clear error when $DOT is unset and ~/.dotfiles is missing, instead of a cryptic Docker mount failure.