### PR TITLE
docs(readme): add verbose workflow comparison section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,223 @@ make uninstall-systemd
 ./uninstall.sh --systemd
 ```
 
+## Workflow Comparison
+
+Each task below is shown three ways — raw Docker, the devcontainer CLI, and `dctl` — so the operational difference is immediately visible.
+
+### Setting Up a New Project
+
+Bootstrap a Python project inside a container:
+
+**Docker:**
+
+```bash
+# 1. Write a Dockerfile (FROM, RUN, USER, WORKDIR, …)
+# 2. Build the image
+docker build -t myproject .
+
+# 3. Start the container
+docker run -it \
+  -v "$PWD:/workspaces/myproject" \
+  -w /workspaces/myproject \
+  --name myproject-dev \
+  myproject
+```
+
+**devcontainer CLI:**
+
+```bash
+# 1. Create the config directory and devcontainer.json
+mkdir -p .devcontainer
+cat > .devcontainer/devcontainer.json <<'JSON'
+{
+  "name": "myproject-sandbox",
+  "image": "devimg/python-dev:latest",
+  "remoteUser": "dev",
+  "mounts": [
+    {
+      "source": "poetry-cache",
+      "target": "/home/dev/.cache/pypoetry",
+      "type": "volume"
+    }
+  ],
+  "postCreateCommand": {
+    "python": "bash -ic dev-py",
+    "pre-commit": "pre-commit install"
+  }
+}
+JSON
+
+# 2. Start the container
+devcontainer up --workspace-folder .
+```
+
+**dctl:**
+
+```bash
+dctl init --template python
+dctl workspace up
+```
+
+`dctl init` copies a ready-made `devcontainer.json` into `.devcontainer/` with image, mounts, and lifecycle hooks pre-configured.
+
+### Running a Command
+
+Execute a test suite inside the running container:
+
+**Docker:**
+
+```bash
+docker exec -it myproject-dev pytest
+```
+
+**devcontainer CLI:**
+
+```bash
+devcontainer exec --workspace-folder . pytest
+```
+
+**dctl:**
+
+```bash
+dctl workspace exec -- pytest
+```
+
+### Interactive Shell
+
+Open a shell session inside the container:
+
+**Docker:**
+
+```bash
+docker exec -it myproject-dev bash
+```
+
+**devcontainer CLI:**
+
+```bash
+devcontainer exec --workspace-folder . bash
+```
+
+**dctl:**
+
+```bash
+dctl workspace shell
+```
+
+### Multiple Terminal Sessions
+
+Attach additional terminals to the same running container:
+
+**Docker:**
+
+```bash
+# terminal 1
+docker exec -it myproject-dev bash
+
+# terminal 2
+docker exec -it myproject-dev bash
+
+# terminal 3 — run an agent
+docker exec -it myproject-dev claude-session
+```
+
+**devcontainer CLI:**
+
+```bash
+# terminal 1
+devcontainer exec --workspace-folder . bash
+
+# terminal 2
+devcontainer exec --workspace-folder . bash
+
+# terminal 3 — run an agent
+devcontainer exec --workspace-folder . claude-session
+```
+
+**dctl:**
+
+```bash
+# terminal 1
+dctl workspace shell
+
+# terminal 2
+dctl workspace shell
+
+# terminal 3 — run an agent
+dctl workspace shell claude-session
+```
+
+Each session shares the same container, filesystem, and installed tools.
+
+### Rebuilding After Config or Image Changes
+
+Recreate the container after changing the Dockerfile or devcontainer.json:
+
+**Docker:**
+
+```bash
+docker build -t myproject .
+docker stop myproject-dev
+docker rm myproject-dev
+docker run -it \
+  -v "$PWD:/workspaces/myproject" \
+  -w /workspaces/myproject \
+  --name myproject-dev \
+  myproject
+```
+
+**devcontainer CLI:**
+
+```bash
+devcontainer up --workspace-folder . --remove-existing-container
+```
+
+**dctl:**
+
+```bash
+dctl workspace reup
+```
+
+### Image Management
+
+Keep base images up to date across projects:
+
+**Docker:**
+
+```bash
+# each project maintains its own Dockerfile
+cd ~/project-a && docker build -t project-a-dev .
+cd ~/project-b && docker build -t project-b-dev .
+# repeat for every project…
+```
+
+**devcontainer CLI:**
+
+```bash
+# no unified image command — each project rebuilds independently
+cd ~/project-a && devcontainer up --workspace-folder .
+cd ~/project-b && devcontainer up --workspace-folder .
+```
+
+The devcontainer CLI has no equivalent of a global image build or image list.
+
+**dctl:**
+
+```bash
+dctl image build --all   # rebuild all managed images once
+dctl image list          # show available targets
+```
+
+`dctl` adds on top of the devcontainer standard:
+
+- Pre-built images with AI agent tools (Claude Code, Codex, Gemini CLI) ready to use.
+- Dotfiles integration baked into base image metadata.
+- Template system for instant project scaffolding (`dctl init`).
+- Unified CLI for images, workspaces, and lifecycle in one tool.
+- Optional systemd timer for weekly unattended image rebuilds.
+- Multi-agent support: attach multiple AI agents to the same container.
+
 ## Further Reading
 
 - [QUICKSTART.md](docs/QUICKSTART.md) — Project setup templates and common commands


### PR DESCRIPTION
Compare Docker vs devcontainer CLI vs dctl across six workflows: project setup, running commands, interactive shell, multiple terminal sessions, rebuilding after changes, and image management. Closes #11.