### PR TITLE
refactor: rename $DOT env var to $DOTFILES

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ systemctl --user enable --now dctl-image-build.timer
 ## Setup
 
 ```bash
-# Build all images (requires dotfiles at ~/.dotfiles or $DOT)
+# Build all images (requires dotfiles at ~/.dotfiles or $DOTFILES)
 dctl image build --all
 
 # Inspect available images
@@ -85,7 +85,7 @@ dctl image build --dry-run        # preview only
 dctl image list                   # show available targets
 ```
 
-The `agents` and `zig-dev` images require the dotfiles repo as a BuildKit named context. Set `DOT=` or ensure `~/.dotfiles` exists.
+The `agents` and `zig-dev` images require the dotfiles repo as a BuildKit named context. Set `DOTFILES=` or ensure `~/.dotfiles` exists.
 
 ### `dctl ws`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,14 +353,14 @@ Or build manually:
 
 ```bash
 cd ~/.local/share/dctl/images
-DOTFILES_DIR="${DOT:-$HOME/.dotfiles}"
+DOTFILES_DIR="${DOTFILES:-$HOME/.dotfiles}"
 docker buildx build --load --build-context dotfiles="$DOTFILES_DIR" --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/agents:latest ./agents/
 docker buildx build --load --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/python-dev:latest ./python-dev/
 docker buildx build --load --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/rust-dev:latest ./rust-dev/
 docker buildx build --load --build-context dotfiles="$DOTFILES_DIR" --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/zig-dev:latest ./zig-dev/
 ```
 
-The `agents` and `zig-dev` images require the dotfiles repo as a BuildKit named context. Set `DOT=` or ensure `~/.dotfiles` exists before building.
+The `agents` and `zig-dev` images require the dotfiles repo as a BuildKit named context. Set `DOTFILES=` or ensure `~/.dotfiles` exists before building.
 
 ---
 
@@ -826,8 +826,8 @@ The `devimg/agents` base image embeds default devcontainer metadata in a Docker 
 | `init` | `true` | Proper init process (PID 1 reaping) |
 | `shutdownAction` | `"none"` | Container keeps running after detach |
 | `containerEnv` | `TERM`, `COLORTERM` | Propagates host terminal defaults |
-| `mounts` | gitconfig, DOT, Claude, gcloud, Codex, OpenCode, Gemini, nvim | Shared auth/editor mounts |
-| `postCreateCommand` | `${localEnv:DOT}/.devcontainer/setup-dotfiles ${localEnv:DOT}` | Shared dotfiles bootstrap |
+| `mounts` | gitconfig, DOTFILES, Claude, gcloud, Codex, OpenCode, Gemini, nvim | Shared auth/editor mounts |
+| `postCreateCommand` | `${localEnv:DOTFILES}/.devcontainer/setup-dotfiles ${localEnv:DOTFILES}` | Shared dotfiles bootstrap |
 
 **NOT in the label** (set per project when needed):
 
@@ -1466,7 +1466,7 @@ docker volume rm mise-cache poetry-cache pip-cache rustup-toolchains cargo-regis
 docker volume prune
 
 # Rebuild from scratch
-DOTFILES_DIR="${DOT:-$HOME/.dotfiles}"
+DOTFILES_DIR="${DOTFILES:-$HOME/.dotfiles}"
 docker buildx build --load --pull --no-cache --build-context dotfiles="$DOTFILES_DIR" --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/agents:latest ~/.local/share/dctl/images/agents/
 docker buildx build --load --no-cache --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/python-dev:latest ~/.local/share/dctl/images/python-dev/
 docker buildx build --load --no-cache --build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -t devimg/rust-dev:latest ~/.local/share/dctl/images/rust-dev/

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -247,12 +247,12 @@ LABEL devcontainer.metadata='[ \
         "readonly": true \
       }, \
       { \
-        "source": "${localEnv:DOT}", \
-        "target": "${localEnv:DOT}", \
+        "source": "${localEnv:DOTFILES}", \
+        "target": "${localEnv:DOTFILES}", \
         "type": "bind" \
       }, \
       { \
-        "source": "${localEnv:DOT}/claude/.claude", \
+        "source": "${localEnv:DOTFILES}/claude/.claude", \
         "target": "${localEnv:HOME}/.claude", \
         "type": "bind" \
       }, \
@@ -262,7 +262,7 @@ LABEL devcontainer.metadata='[ \
         "type": "bind" \
       }, \
       { \
-        "source": "${localEnv:DOT}/claude/.local/bin/claude-session", \
+        "source": "${localEnv:DOTFILES}/claude/.local/bin/claude-session", \
         "target": "${localEnv:HOME}/.local/bin/claude-session", \
         "type": "bind" \
       }, \
@@ -273,7 +273,7 @@ LABEL devcontainer.metadata='[ \
         "readonly": true \
       }, \
       { \
-        "source": "${localEnv:DOT}/codex/.codex", \
+        "source": "${localEnv:DOTFILES}/codex/.codex", \
         "target": "${localEnv:HOME}/.codex", \
         "type": "bind" \
       }, \
@@ -283,23 +283,23 @@ LABEL devcontainer.metadata='[ \
         "type": "bind" \
       }, \
       { \
-        "source": "${localEnv:DOT}/opencode/.config/opencode", \
+        "source": "${localEnv:DOTFILES}/opencode/.config/opencode", \
         "target": "${localEnv:HOME}/.config/opencode", \
         "type": "bind" \
       }, \
       { \
-        "source": "${localEnv:DOT}/gemini/.gemini", \
+        "source": "${localEnv:DOTFILES}/gemini/.gemini", \
         "target": "${localEnv:HOME}/.gemini", \
         "type": "bind" \
       }, \
       { \
-        "source": "${localEnv:DOT}/nvim/.config/nvim", \
+        "source": "${localEnv:DOTFILES}/nvim/.config/nvim", \
         "target": "${localEnv:HOME}/.config/nvim", \
         "type": "bind" \
       } \
     ], \
     "postCreateCommand": { \
-      "dotfiles": "${localEnv:DOT}/.devcontainer/setup-dotfiles ${localEnv:DOT}" \
+      "dotfiles": "${localEnv:DOTFILES}/.devcontainer/setup-dotfiles ${localEnv:DOTFILES}" \
     } \
   } \
 ]'

--- a/lib/dctl/image.sh
+++ b/lib/dctl/image.sh
@@ -202,7 +202,7 @@ cmd_image_build() {
 
   local username dotfiles_dir
   username="${USER:-$(id -un)}"
-  dotfiles_dir="${DOT:-${HOME}/.dotfiles}"
+  dotfiles_dir="${DOTFILES:-${HOME}/.dotfiles}"
   local -a build_args
   build_args=(--build-arg "USERNAME=${username}" --build-arg "USER_UID=$(id -u)" --build-arg "USER_GID=$(id -g)")
 
@@ -223,7 +223,7 @@ cmd_image_build() {
       elif [[ "$dry_run" == true ]]; then
         warn "Dotfiles not found at ${dotfiles_dir} - agents/zig-dev build would fail"
       else
-        err "Dotfiles not found at ${dotfiles_dir} - set DOT= or ensure ~/.dotfiles exists"
+        err "Dotfiles not found at ${dotfiles_dir} - set DOTFILES= or ensure ~/.dotfiles exists"
       fi
     fi
 

--- a/lib/dctl/ws.sh
+++ b/lib/dctl/ws.sh
@@ -10,9 +10,9 @@ readonly _DCTL_WS_LOADED=1
 source "${DCTL_LIB_DIR}/common.sh"
 
 require_dotfiles_dir() {
-  DOT="${DOT:-${HOME}/.dotfiles}"
-  [[ -d "$DOT" ]] || err "Dotfiles not found at ${DOT} — set DOT= or ensure ~/.dotfiles exists"
-  export DOT
+  DOTFILES="${DOTFILES:-${HOME}/.dotfiles}"
+  [[ -d "$DOTFILES" ]] || err "Dotfiles not found at ${DOTFILES} — set DOTFILES= or ensure ~/.dotfiles exists"
+  export DOTFILES
 }
 
 usage_ws() {

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -408,7 +408,7 @@ teardown() {
   enable_mocks
   create_mock devcontainer 0 ""
 
-  unset DOT
+  unset DOTFILES
   HOME="$missing_home" run cmd_ws_up
   [ "$status" -eq 1 ]
   [[ "$output" == *"Dotfiles not found"* ]]
@@ -423,19 +423,19 @@ teardown() {
   enable_mocks
   create_mock devcontainer 0 ""
 
-  unset DOT
+  unset DOTFILES
   HOME="$missing_home" run cmd_ws_reup
   [ "$status" -eq 1 ]
   [[ "$output" == *"Dotfiles not found"* ]]
   assert_mock_not_called "devcontainer "
 }
 
-@test "ws up calls devcontainer when DOT is valid" {
+@test "ws up calls devcontainer when DOTFILES is valid" {
   enable_mocks
   create_mock devcontainer 0 ""
 
-  DOT="${TEST_TMPDIR}/dotfiles"
-  mkdir -p "$DOT"
+  DOTFILES="${TEST_TMPDIR}/dotfiles"
+  mkdir -p "$DOTFILES"
 
   run cmd_ws_up
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Migrate all references from the DOT environment variable to DOTFILES across runtime code, Dockerfile image labels, tests, and documentation.