### PR TITLE
refactor(ws): rename worktree mount helper and add test coverage

### DIFF
--- a/lib/dctl/ws.sh
+++ b/lib/dctl/ws.sh
@@ -80,6 +80,31 @@ ensure_ws_container_running() {
   cmd_ws_up
 }
 
+# If the workspace is a git linked worktree, populate mount args for the
+# shared .git directory so git operations work inside the container.
+# Usage: local -a git_wt_mounts=(); collect_git_worktree_mounts git_wt_mounts
+collect_git_worktree_mounts() {
+  local -n _out="$1"
+  _out=()
+
+  command -v git &>/dev/null || return 0
+
+  local git_dir common_dir
+  git_dir="$(git -C "$WORKSPACE_FOLDER" rev-parse --git-dir 2>/dev/null)" || return 0
+  common_dir="$(git -C "$WORKSPACE_FOLDER" rev-parse --git-common-dir 2>/dev/null)" || return 0
+
+  # Resolve to absolute paths
+  git_dir="$(cd -- "$WORKSPACE_FOLDER" && cd -- "$git_dir" && pwd -P)"
+  common_dir="$(cd -- "$WORKSPACE_FOLDER" && cd -- "$common_dir" && pwd -P)"
+
+  # Not a linked worktree — git dir and common dir are identical
+  [[ "$git_dir" != "$common_dir" ]] || return 0
+
+  # Mount the shared .git directory at the same host path inside the container
+  # so the absolute gitdir reference in the worktree's .git file resolves
+  _out=(--mount "type=bind,source=${common_dir},target=${common_dir}")
+}
+
 collect_term_env() {
   local -n out="$1"
   out=()
@@ -106,8 +131,10 @@ cmd_ws_up() {
     args=("${args[@]:1}")
   fi
 
+  local -a git_wt_mounts=()
+  collect_git_worktree_mounts git_wt_mounts
   log "Starting devcontainer for $(workspace_path)"
-  devcontainer up --workspace-folder "$WORKSPACE_FOLDER" "${args[@]}"
+  devcontainer up --workspace-folder "$WORKSPACE_FOLDER" "${git_wt_mounts[@]}" "${args[@]}"
 }
 
 cmd_ws_reup() {
@@ -118,8 +145,10 @@ cmd_ws_reup() {
     args=("${args[@]:1}")
   fi
 
+  local -a git_wt_mounts=()
+  collect_git_worktree_mounts git_wt_mounts
   log "Recreating devcontainer for $(workspace_path)"
-  devcontainer up --workspace-folder "$WORKSPACE_FOLDER" --remove-existing-container "${args[@]}"
+  devcontainer up --workspace-folder "$WORKSPACE_FOLDER" --remove-existing-container "${git_wt_mounts[@]}" "${args[@]}"
 }
 
 cmd_ws_exec() {

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -45,6 +45,9 @@ setup() {
   # shellcheck disable=SC2329
   workspace_devcontainer_file() { printf '%s/.devcontainer/devcontainer.json\n' "$WORKSPACE_FOLDER"; }
   unset TERM COLORTERM TERM_PROGRAM TERM_PROGRAM_VERSION 2>/dev/null || true
+  # Clear git env leaked by pre-commit so in-test git repos work correctly
+  unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_OBJECT_DIRECTORY \
+    GIT_ALTERNATE_OBJECT_DIRECTORIES 2>/dev/null || true
 }
 
 teardown() {
@@ -428,6 +431,52 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"Dotfiles not found"* ]]
   assert_mock_not_called "devcontainer "
+}
+
+# --- Git worktree mount detection ---
+
+@test "collect_git_worktree_mounts returns empty for non-git workspace" {
+  local -a mounts=()
+  collect_git_worktree_mounts mounts
+  [ "${#mounts[@]}" -eq 0 ]
+}
+
+@test "collect_git_worktree_mounts returns empty for regular git repo" {
+  git -C "$WORKSPACE_FOLDER" init -q
+  local -a mounts=()
+  collect_git_worktree_mounts mounts
+  [ "${#mounts[@]}" -eq 0 ]
+}
+
+@test "collect_git_worktree_mounts returns mount for linked worktree" {
+  local main_repo="${TEST_TMPDIR}/main-repo"
+  mkdir -p "$main_repo"
+  git -C "$main_repo" init -q
+  git -C "$main_repo" commit --allow-empty -m "init"
+  # Create the linked worktree at $WORKSPACE_FOLDER (which is already set and readonly)
+  rm -rf "$WORKSPACE_FOLDER"
+  git -C "$main_repo" worktree add "$WORKSPACE_FOLDER" -b test-branch
+
+  local -a mounts=()
+  collect_git_worktree_mounts mounts
+  [ "${#mounts[@]}" -eq 2 ]
+  [ "${mounts[0]}" = "--mount" ]
+  [[ "${mounts[1]}" == "type=bind,source=${main_repo}/.git,target=${main_repo}/.git" ]]
+}
+
+@test "ws up includes git worktree mount for linked worktree" {
+  local main_repo="${TEST_TMPDIR}/main-repo"
+  mkdir -p "$main_repo"
+  git -C "$main_repo" init -q
+  git -C "$main_repo" commit --allow-empty -m "init"
+  git -C "$main_repo" worktree add "$WORKSPACE_FOLDER" -b test-branch
+
+  enable_mocks
+  create_mock devcontainer 0 ""
+
+  run cmd_ws_up
+  [ "$status" -eq 0 ]
+  assert_mock_called "--mount type=bind,source=${main_repo}/.git,target=${main_repo}/.git"
 }
 
 @test "ws up calls devcontainer when DOTFILES is valid" {


### PR DESCRIPTION
Move git linked worktree detection from common.sh to ws.sh as collect_git_worktree_mounts — uses pure git terminology, adds a `command -v git` guard, and follows the existing collect_term_env pattern. Add four tests covering non-git, regular repo, linked worktree, and end-to-end ws-up integration.