### PR TITLE
feat(rust-dev): add cargo-nextest testing tool

### DIFF
--- a/images/rust-dev/Dockerfile
+++ b/images/rust-dev/Dockerfile
@@ -15,6 +15,7 @@ RUN cargo binstall --no-confirm --locked cargo-deny \
     && cargo binstall --no-confirm --locked taplo-cli \
     && cargo binstall --no-confirm --locked cargo-audit \
     && cargo binstall --no-confirm --locked typos-cli \
+    && cargo binstall --no-confirm --locked cargo-nextest \
     && cargo binstall --no-confirm --locked ripsecrets
 
 # Pre-commit tools installed via mise (non-cargo binaries)


### PR DESCRIPTION
Installs cargo-nextest via cargo binstall in the rust-dev container to provide next-generation test runner capabilities.

- Adds cargo-nextest to container tooling
- Uses locked version from cargo binstall