### PR TITLE
feat(agents/Dockerfile): add bubblewrap system dependency for Codex CLI

### DIFF
--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
     fd-find \
     bat \
+    # Codex CLI: unprivileged sandbox backend (/usr/bin/bwrap)
+    bubblewrap \
     fish \
     jq \
     tree \


### PR DESCRIPTION
Codex CLI v0.115.0+ uses bubblewrap (bwrap) as the default filesystem sandbox on Linux. Without the system package installed at /usr/bin/bwrap, Codex emits a warning and falls back to its vendored binary.

- Add bubblewrap to apt-get install block
- Include explanatory comment about Codex CLI sandbox backend
- No supply chain note update needed (standard Debian apt package)