### PR TITLE
feat(image): pass GitHub token as secret to avoid rate limits

### DIFF
--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -119,7 +119,9 @@ RUN cargo install cargo-binstall --locked \
     && cargo binstall --no-confirm --locked shellharden
 
 # Node.js LTS via mise (needed for bun-installed packages with #!/usr/bin/env node shebangs)
-RUN mise use --global node@lts \
+RUN --mount=type=secret,id=gh_token,mode=0444 \
+    export GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    && mise use --global node@lts \
     && mise reshim
 
 # Neovim (latest stable) + Python + pre-commit + fzf + glab via mise
@@ -127,9 +129,14 @@ RUN mise use --global node@lts \
 # rolling model. If a backend drifts, the build breaks loud — fix forward.
 # Refresh mise binary: cached cargo-binstall version may have registry/parser bugs
 # hadolint ignore=DL3013
-RUN curl -fsSL https://mise.run | MISE_INSTALL_PATH="$HOME/.cargo/bin/mise" sh \
+RUN --mount=type=secret,id=gh_token,mode=0444 \
+    export GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    && curl -fsSL https://mise.run | MISE_INSTALL_PATH="$HOME/.cargo/bin/mise" sh \
     && mise use --global neovim@latest \
-    && mise use --global python@latest \
+    # Force standard (non-freethreaded) Python: 3.14+ defaults to freethreaded builds
+    # (no GIL), whose stripped precompiled binaries lack the lib/ dir mise expects.
+    # Standard build keeps full compatibility with C extensions and conventional layout.
+    && MISE_PYTHON_PRECOMPILED_FLAVOR=install_only_stripped mise use --global python@latest \
     && mise use --global pre-commit@latest \
     && mise use --global fzf@latest \
     && mise use --global gitlab:gitlab-org/cli@latest \

--- a/images/python-dev/Dockerfile
+++ b/images/python-dev/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 USER $USERNAME
 
 # Poetry + yq (provides tomlq for pyproject parsing) via mise pipx backend
-RUN mise use --global pipx:poetry@latest \
+RUN --mount=type=secret,id=gh_token,mode=0444 \
+    export GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    && mise use --global pipx:poetry@latest \
     && mise use --global pipx:yq@latest \
     && mise reshim
 

--- a/images/rust-dev/Dockerfile
+++ b/images/rust-dev/Dockerfile
@@ -19,7 +19,9 @@ RUN cargo binstall --no-confirm --locked cargo-deny \
     && cargo binstall --no-confirm --locked ripsecrets
 
 # Pre-commit tools installed via mise (non-cargo binaries)
-RUN mise use --global gitleaks@latest \
+RUN --mount=type=secret,id=gh_token,mode=0444 \
+    export GITHUB_TOKEN="$(cat /run/secrets/gh_token 2>/dev/null || true)" \
+    && mise use --global gitleaks@latest \
     && mise reshim
 
 # Remove default toolchain (project declares in rust-toolchain.toml)

--- a/lib/dctl/image.sh
+++ b/lib/dctl/image.sh
@@ -8,6 +8,8 @@ readonly _DCTL_IMAGE_LOADED=1
 
 # shellcheck source=/dev/null
 source "${DCTL_LIB_DIR}/common.sh"
+# shellcheck source=/dev/null
+source "${DCTL_LIB_DIR}/auth.sh"
 
 usage_image() {
   cat <<'EOF'
@@ -206,6 +208,20 @@ cmd_image_build() {
   local -a build_args
   build_args=(--build-arg "USERNAME=${username}" --build-arg "USER_UID=$(id -u)" --build-arg "USER_GID=$(id -g)")
 
+  # GitHub token for mise installs (avoids 60 req/hr anonymous rate limit)
+  local -a secret_flag=()
+  local gh_token_file=""
+  if [[ "$dry_run" != true ]]; then
+    local gh_token
+    if gh_token=$(_extract_gh_token 2>/dev/null) && [[ -n "$gh_token" ]]; then
+      gh_token_file=$(mktemp)
+      printf '%s' "$gh_token" > "$gh_token_file"
+      secret_flag=(--secret "id=gh_token,src=${gh_token_file}")
+    else
+      warn "No GitHub token found — builds may hit API rate limits (see: gh auth login)"
+    fi
+  fi
+
   local -a failed
   failed=()
 
@@ -267,12 +283,15 @@ cmd_image_build() {
       "${refresh_flag[@]}" \
       "${extra_contexts[@]}" \
       "${build_args[@]}" \
+      "${secret_flag[@]}" \
       -t "$tag" \
       "./${target}/"; then
       warn "Failed to build: $target"
       failed+=("$target")
     fi
   done
+
+  [[ -n "$gh_token_file" ]] && rm -f "$gh_token_file"
 
   if [[ "$dry_run" == true ]]; then
     log "Dry-run complete"


### PR DESCRIPTION
Inject GITHUB_TOKEN into mise RUN steps via BuildKit --mount=type=secret to avoid GitHub's 60 req/hr anonymous API rate limit during image builds.

- Source auth.sh in image.sh and extract GH token via _extract_gh_token
- Write token to a temp file and pass as --secret flag to docker build
- Mount the secret in each Dockerfile RUN that calls mise use
- Clean up the temp token file after build completes
- Pin Python to standard (non-freethreaded) flavor in agents Dockerfile to fix mise compatibility with 3.14+ precompiled builds