### PR TITLE
Solves issue "#112 Migrate container base image from Debian trixie-slim to openSUSE Leap 16.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Runs the workspace smoke test: prerequisite checks, managed image build if neede
 ## Image Architecture
 
 ```text
-Debian trixie-slim
+openSUSE Leap 16.0
         │
         ▼
 devimg/agents:latest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,7 +170,7 @@ The spec set remains useful as a design record and glossary:
 Separate agent tools from language tooling for better caching:
 
 ```text
-devimg/agents:latest    (Debian bookworm + bun + node LTS + agent CLIs + mise + build deps)
+devimg/agents:latest    (openSUSE Leap 16.0 + bun + node LTS + agent CLIs + mise + build deps)
        │
        ├── devimg/python-dev:latest   (poetry via mise; inherits base python, overridden by project pin)
        ├── devimg/rust-dev:latest     (rustup with no default toolchain)
@@ -247,12 +247,12 @@ The container user is created with the same name as your host `$USER`, and UID/G
 
 ### Layer 0: Agent Tools Base (agents/)
 
-Foundation layer using Debian trixie-slim for broad compatibility and package availability.
+Foundation layer using openSUSE Leap 16.0 for broad compatibility and package availability.
 
 **Includes**:
 
-- System packages: git, ripgrep, fd-find (symlinked as fd), fzf, jq, build tools (build-essential, pkg-config)
-- [Bun](https://bun.com/) as JavaScript runtime for agent CLIs (curl install - no apt package)
+- System packages: git, ripgrep, fd, jq, build tools (gcc/g++/make/binutils toolchain, pkg-config)
+- [Bun](https://bun.com/) as JavaScript runtime for agent CLIs (curl install - no distro package)
 - [Node.js](https://nodejs.org/) LTS via mise (required for bun-installed package shebangs)
 - [mise](https://mise.jdx.dev/) for runtime version management
 - [GitHub CLI (gh)](https://github.com/cli/cli) for GitHub workflows
@@ -279,7 +279,7 @@ Native installers are preferred over Homebrew in containers (Homebrew adds ~500M
 
 | Tool | Method | Command |
 | ---- | ------ | ------- |
-| gh (GitHub CLI) | Official APT repo | Keyring + `sources.list.d` entry in `images/agents/Dockerfile` |
+| gh (GitHub CLI) | Official RPM repo | `zypper addrepo` of `https://cli.github.com/packages/rpm/gh-cli.repo` in `images/agents/Dockerfile` |
 | glab (GitLab CLI) | mise (GitLab releases) | `mise use --global gitlab:gitlab-org/cli@latest` |
 
 **Notes**:
@@ -1218,9 +1218,9 @@ systemctl --user enable --now dctl-image-build.timer
 FROM devimg/python-dev:latest
 
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1 \
-    && rm -rf /var/lib/apt/lists/*
+RUN zypper --non-interactive install --no-recommends \
+        Mesa-libGL1 \
+    && zypper clean --all
 USER $USERNAME
 ```
 
@@ -1624,6 +1624,6 @@ monorepo packages alongside it.
 - JSON Reference: <https://containers.dev/implementors/json_reference/>
 - Devcontainer CLI: <https://github.com/devcontainers/cli>
 - Features Registry: <https://containers.dev/features>
-- Debian Packages: <https://packages.debian.org/bookworm/>
+- openSUSE Packages: <https://software.opensuse.org/>
 - mise Documentation: <https://mise.jdx.dev/>
 - rustup Documentation: <https://rust-lang.github.io/rustup/>

--- a/docs/DOCKER-CLEANUP.md
+++ b/docs/DOCKER-CLEANUP.md
@@ -1,0 +1,264 @@
+# Docker & Devcontainer Cleanup Guide
+
+Operator guide for reclaiming disk and removing legacy Docker/BuildKit/devcontainer state. Ordered from **inspect → safe cleanup → targeted dctl cleanup → aggressive reset**. Use the earliest step that solves your problem.
+
+> Quick mental model. Docker keeps five things that grow: **containers** (stopped or running), **images** (tagged, untagged/dangling), **volumes** (named + anonymous), **networks** (ephemeral per `docker compose` / devcontainer run), and the **BuildKit cache** (layer blobs + intermediate stages). Each needs its own command to reclaim — `docker system prune` skips some of them by default.
+
+## 1. Inspect what you have
+
+Before deleting anything, measure.
+
+```bash
+# Overall usage: containers, images, volumes, build cache (sizes and reclaimable)
+docker system df
+
+# Detailed per-object breakdown
+docker system df -v | less
+
+# Images grouped by repository, largest first
+docker images --format '{{.Size}}\t{{.Repository}}:{{.Tag}}\t{{.ID}}' | sort -h
+
+# Stopped containers (candidates for removal)
+docker ps -a --filter status=exited --filter status=dead --filter status=created \
+  --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}'
+
+# Dangling images (untagged, produced by rebuilds)
+docker images --filter dangling=true
+
+# Unused volumes (no container references them)
+docker volume ls --filter dangling=true
+
+# BuildKit cache usage
+docker buildx du | head
+```
+
+## 2. Safe cleanup (non-destructive to running work)
+
+Each step is independent — run any subset. None of these touch running containers or tagged images you still use.
+
+```bash
+# Remove stopped containers
+docker container prune -f
+
+# Remove dangling (untagged) images
+docker image prune -f
+
+# Remove unused networks
+docker network prune -f
+
+# Remove BuildKit layers unused for >72h (keep recent rebuild speed)
+docker buildx prune --filter 'until=72h' -f
+
+# Remove volumes not referenced by any container
+#   WARNING: devcontainers often keep volumes (e.g. dotfiles cache, bun cache,
+#   cargo target). If you rely on those, skip this or use the targeted form below.
+docker volume prune -f
+```
+
+Verify reclamation:
+
+```bash
+docker system df
+```
+
+## 3. Targeted dctl-aware cleanup
+
+`dctl` tags its images `devimg/<name>:latest` and labels its devcontainers with `devcontainer.local_folder=<workspace-path>`. Use these to clean up without touching other Docker work on the host.
+
+### 3.1 Devcontainer for the current workspace
+
+```bash
+# From inside the workspace directory:
+dctl ws status    # see what's there
+dctl ws down      # remove the container for this workspace
+```
+
+`dctl ws down` removes only the containers labeled with the current workspace path. It does not touch images, volumes, or other workspaces.
+
+### 3.2 All dctl-managed workspace containers (any workspace)
+
+```bash
+docker ps -a --filter 'label=devcontainer.local_folder' \
+  --format 'table {{.ID}}\t{{.Status}}\t{{.Label "devcontainer.local_folder"}}\t{{.Image}}'
+
+# Remove them all (running or stopped):
+docker ps -aq --filter 'label=devcontainer.local_folder' | xargs -r docker rm -f
+```
+
+### 3.3 dctl-managed images
+
+```bash
+# List managed images
+docker images 'devimg/*'
+
+# Remove a single managed image (forces rebuild next time)
+docker image rm devimg/python-dev:latest
+
+# Remove ALL managed images (safe — rebuild via `dctl image build --full-rebuild`)
+docker images --format '{{.Repository}}:{{.Tag}}' 'devimg/*' | xargs -r docker image rm
+```
+
+### 3.4 Post-migration: wipe the old Debian-based image chain
+
+After migrating the base image (Debian → openSUSE Leap 16.0, or any similar base change), the old layers stay cached and can eat tens of GB.
+
+```bash
+# 1. Make sure no workspace is running against the old images:
+docker ps -a --filter 'label=devcontainer.local_folder'
+#    → if any container shows an old image, `dctl ws down` in its workspace or
+#    `docker rm -f <id>` on it.
+
+# 2. Remove all dctl-managed tags (old and new — you'll rebuild them):
+docker images --format '{{.Repository}}:{{.Tag}}' 'devimg/*' | xargs -r docker image rm
+
+# 3. Remove the now-dangling Debian base layers pulled as parents:
+docker image prune -f
+
+# 4. (Optional) also drop the Debian base itself, if nothing else uses it:
+docker image rm debian:trixie-slim debian:bookworm 2>/dev/null || true
+
+# 5. Drop BuildKit cache layers for the old chain:
+docker buildx prune -f
+#    Add `--all` if you want to nuke every cached layer (slower next build).
+
+# 6. Rebuild from the new base with no cache:
+dctl image build --full-rebuild
+```
+
+Steps 2 + 5 are the main space-reclaimers after a base swap.
+
+## 4. Aggressive reset (destroys everything Docker)
+
+Use only when you genuinely want a clean Docker state. **This stops and removes every container, image, volume, and cache on the host** — not just dctl's. Never run this on a host that hosts production workloads.
+
+```bash
+# Stop and remove every container (running or not)
+docker ps -aq | xargs -r docker rm -f
+
+# Remove every image
+docker images -q | xargs -r docker image rm -f
+
+# Remove every volume
+docker volume ls -q | xargs -r docker volume rm -f
+
+# Remove every network (except the built-ins `bridge`, `host`, `none`)
+docker network ls -q --filter 'type=custom' | xargs -r docker network rm
+
+# Nuke the entire BuildKit cache
+docker buildx prune --all -f
+
+# One-shot equivalent for everything the API will prune:
+docker system prune --all --volumes -f
+```
+
+`docker system prune --all --volumes -f` is the closest single command, but it still leaves: (a) running containers, (b) named volumes not created by `docker volume create` but attached to a removed container (usually safe), (c) BuildKit cache older than the current builder — run `docker buildx prune --all -f` separately to guarantee it.
+
+### 4.1 Full Docker daemon reset (host-level, last resort)
+
+If Docker itself is in a bad state (stuck daemon, corrupt storage driver, etc.):
+
+```bash
+sudo systemctl stop docker docker.socket
+sudo rm -rf /var/lib/docker             # destroys every image, container, volume
+sudo systemctl start docker
+```
+
+This is destructive *and* requires root. Prefer step 4 first.
+
+## 5. Devcontainer-specific leftovers
+
+The `devcontainer` CLI (used by `dctl ws up`) caches feature installers and intermediate images. These usually get pruned by the above steps, but can linger.
+
+```bash
+# Devcontainer CLI cache (feature layers, dev-container builds)
+rm -rf ~/.devcontainer/                 # CLI state
+rm -rf ~/.cache/devcontainers-cli/      # some versions
+rm -rf ~/.cache/dctl/                   # dctl resolved state (safe — recomputed)
+
+# Per-project ephemeral state (dctl writes nothing here by default, but check):
+find . -name '.devcontainer.build-*' -type d
+```
+
+The `dctl` CLI keeps its own state under `~/.config/dctl/` (configuration — do **not** delete unless reinstalling) and `~/.cache/dctl/` (regenerable — safe to delete).
+
+## 6. Routine housekeeping
+
+Add this to a weekly cron / systemd timer to keep things in check without manual work:
+
+```bash
+# /etc/cron.weekly/docker-cleanup  (chmod +x)
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker container prune -f
+docker image prune -f
+docker network prune -f
+docker buildx prune --filter 'until=168h' -f   # keep one week of build cache
+# Skip `volume prune` in automation — too easy to lose devcontainer state.
+```
+
+For a systemd timer instead of cron, model it after the existing `systemd/dctl-image-build.timer` in this repo.
+
+## 7. Verify reclamation worked
+
+```bash
+# Before:
+docker system df
+
+# Clean up:
+# ... run the steps you picked from above ...
+
+# After:
+docker system df
+```
+
+The "RECLAIMABLE" column in `docker system df` should drop toward 0% for each row you targeted. If it doesn't, something still references those objects — rerun `docker ps -a` and `docker images --all` to find out what.
+
+## 8. One-shot full wipe
+
+Single copy-pasteable block to remove **everything** dctl, Docker, and devcontainer-related on the host. Combines sections 2, 3, 4, 4.1, and 5 into one sequence. **Destroys every container, image, volume, network, BuildKit cache, and CLI state on the host** — not just dctl's. Never run on a host with production workloads.
+
+```bash
+# 1. Stop and remove every container (running or not)
+docker ps -aq | xargs -r docker rm -f
+
+# 2. Remove every image
+docker images -q | xargs -r docker image rm -f
+
+# 3. Remove every volume
+docker volume ls -q | xargs -r docker volume rm -f
+
+# 4. Remove every custom network
+docker network ls -q --filter 'type=custom' | xargs -r docker network rm
+
+# 5. Nuke the entire BuildKit cache
+docker buildx prune --all -f
+
+# 6. One-shot API-level prune as a safety net
+docker system prune --all --volumes -f
+
+# 7. Remove devcontainer CLI and dctl cache/state
+rm -rf ~/.devcontainer/
+rm -rf ~/.cache/devcontainers-cli/
+rm -rf ~/.cache/dctl/
+
+# 8. (Last resort) full Docker daemon reset — requires root, destroys /var/lib/docker
+sudo systemctl stop docker docker.socket
+sudo rm -rf /var/lib/docker
+sudo systemctl start docker
+```
+
+Verify with `docker system df` — every row should report 0B / 0% reclaimable. To rebuild dctl-managed images from scratch afterwards:
+
+```bash
+dctl image build --full-rebuild
+```
+
+Step 8 is optional and only needed if the daemon itself is in a bad state. `~/.config/dctl/` is preserved — delete it manually only if reinstalling dctl from zero.
+
+## References
+
+- Docker prune docs: <https://docs.docker.com/engine/manage-resources/pruning/>
+- BuildKit cache management: <https://docs.docker.com/build/cache/>
+- `dctl` CLI surface: `dctl help`, `dctl image help`, `dctl ws help`
+- Related repo docs: [ARCHITECTURE.md](ARCHITECTURE.md), [QUICKSTART.md](QUICKSTART.md)

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Supply chain note: Bun, Claude Code, OpenCode, and the mise
 # refresh are installed via curl-pipe. Codex is installed via Bun (npm-style).
-# gh is installed via the official GitHub APT repo. Node.js LTS, Neovim,
+# gh is installed via the official GitHub RPM repo. Node.js LTS, Neovim,
 # Python, fzf, pre-commit, glab, bats, and yq are installed via mise. eza, mise, zoxide,
 # and starship are installed via cargo-binstall.
 # trash-cli via pipx. Rust toolchain via rustup. Neovim runs a minimal
@@ -11,49 +11,53 @@
 # guarantees, pin versions and validate checksums. Current approach favors
 # simplicity for personal devcontainers with weekly rebuilds.
 
-FROM debian:trixie-slim
+FROM opensuse/leap:16.0
 
-ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # System dependencies + build tools for native extensions
-# Package names follow Debian conventions. Verify availability with:
-#   docker run --rm debian:trixie-slim bash -c "apt-get update && apt-cache policy <pkg>"
-# Or check: https://packages.debian.org/trixie/
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    git \
-    unzip \
-    ripgrep \
-    fd-find \
-    bat \
-    fish \
-    jq \
-    tree \
-    htop \
-    sudo \
-    openssh-client \
-    rsync \
-    stow \
-    # Kitty terminal: terminfo for xterm-kitty (enables keyboard protocol inside containers)
-    kitty-terminfo \
-    # Build dependencies (for Python wheels, Rust crates, etc.)
-    build-essential \
-    libffi-dev \
-    libssl-dev \
-    pkg-config \
-    libclang-dev \
-    libdbus-1-dev \
-    # X11 build dependencies (suckless: dwm, st, dmenu, etc.)
-    libx11-dev \
-    libxft-dev \
-    libxinerama-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    # Create fd symlink (Debian names binary fdfind to avoid conflict)
-    && if [ -x /usr/bin/fdfind ]; then ln -sf /usr/bin/fdfind /usr/local/bin/fd; fi \
-    && if [ -x /usr/bin/batcat ]; then ln -sf /usr/bin/batcat /usr/local/bin/bat; fi
+# Package names follow openSUSE conventions. Verify availability with:
+#   docker run --rm opensuse/leap:16.0 bash -c "zypper --non-interactive refresh && zypper info <pkg>"
+# Or check: https://software.opensuse.org/package/<pkg>
+# hadolint ignore=DL3037
+RUN zypper --non-interactive --gpg-auto-import-keys refresh \
+    && zypper --non-interactive install --no-recommends \
+        ca-certificates \
+        ca-certificates-mozilla \
+        curl \
+        git-core \
+        unzip \
+        ripgrep \
+        fd \
+        bat \
+        fish \
+        jq \
+        tree \
+        htop \
+        sudo \
+        openssh-clients \
+        rsync \
+        stow \
+        # Kitty terminal: terminfo for xterm-kitty (enables keyboard protocol inside containers)
+        kitty-terminfo \
+        # Build dependencies (for Python wheels, Rust crates, etc.)
+        gcc \
+        gcc-c++ \
+        make \
+        binutils \
+        glibc-devel \
+        libffi-devel \
+        libopenssl-3-devel \
+        pkgconf-pkg-config \
+        clang-devel \
+        llvm-devel \
+        dbus-1-devel \
+        # X11 build dependencies (suckless: dwm, st, dmenu, etc.)
+        libX11-devel \
+        libXft-devel \
+        libXinerama-devel \
+    && zypper clean --all
 
 # Non-root user with passwordless sudo
 # USERNAME must match host $USER for config file consistency
@@ -71,22 +75,18 @@ RUN test -n "$USERNAME" || { echo "USERNAME build arg is required"; exit 1; } \
 # Pre-create directories for mounts
 RUN install -d -m 0700 -o $USERNAME -g $USERNAME /home/$USERNAME/.ssh
 
-# fzf-tab-completion: bash Tab completion via fzf (no Debian package available)
+# fzf-tab-completion: bash Tab completion via fzf (installed from upstream repo)
 # Checked first by bash/.config/bash/rc.d/10-fzf.bash
 RUN git clone --depth=1 https://github.com/lincheney/fzf-tab-completion /usr/share/fzf-tab-completion \
     && rm -rf /usr/share/fzf-tab-completion/.git \
     && test -r /usr/share/fzf-tab-completion/bash/fzf-bash-completion.sh
 
-# GitHub CLI (gh): official APT repo tracks latest releases for Debian
-RUN mkdir -p -m 755 /etc/apt/keyrings \
-    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-        > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
-    && rm -rf /var/lib/apt/lists/*
+# GitHub CLI (gh): official RPM repo tracks latest releases for openSUSE/Fedora/RHEL
+# hadolint ignore=DL3037
+RUN zypper --non-interactive addrepo https://cli.github.com/packages/rpm/gh-cli.repo \
+    && zypper --non-interactive --gpg-auto-import-keys refresh \
+    && zypper --non-interactive install --no-recommends gh \
+    && zypper clean --all
 
 USER $USERNAME
 WORKDIR /home/$USERNAME

--- a/images/python-dev/Dockerfile
+++ b/images/python-dev/Dockerfile
@@ -12,10 +12,11 @@ USER $USERNAME
 
 # System deps for native Python extensions (M2Crypto needs swig + OpenSSL headers)
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    swig \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+# hadolint ignore=DL3037
+RUN zypper --non-interactive install --no-recommends \
+        swig \
+        libopenssl-3-devel \
+    && zypper clean --all
 USER $USERNAME
 
 # Poetry + yq (provides tomlq for pyproject parsing) via mise pipx backend

--- a/images/zig-dev/Dockerfile
+++ b/images/zig-dev/Dockerfile
@@ -11,12 +11,12 @@ RUN test -n "$USERNAME" || { echo "USERNAME build arg is required"; exit 1; }
 USER $USERNAME
 
 # System deps: minisign (zig-zls-init signature verification),
-# xz-utils (tar -xJ for zls archives)
+# xz (tar -xJ for zls archives)
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    minisign \
-    xz-utils \
-    && rm -rf /var/lib/apt/lists/*
+RUN zypper --non-interactive install --no-recommends \
+        minisign \
+        xz \
+    && zypper clean --all
 USER $USERNAME
 
 # anyzig: multi-version zig launcher (reads version from build.zig.zon)


### PR DESCRIPTION
Closes #112

## Summary

Migrate the container base image from Debian trixie-slim to openSUSE Leap 16.0 to improve package availability and compatibility. This change updates all package manager commands, package names, and installation methods across the build system.

## Key Changes

- **Base Image**: Updated `FROM debian:trixie-slim` to `FROM opensuse/leap:16.0`
- **Package Manager**: Migrated from APT to zypper with equivalent commands and syntax
- **Build Toolchain**: Replaced `build-essential` with individual packages (`gcc`, `g++`, `make`, `binutils`)
- **Development Packages**: Updated X11 and system library names to openSUSE conventions (e.g., `libx11-dev` → `libX11-devel`, `libgl1` → `Mesa-libGL1`)
- **GitHub CLI**: Migrated from official APT repository to official RPM repository configuration
- **Package Cleanup**: Changed from `rm -rf /var/lib/apt/lists/*` to `zypper clean --all`
- **Removed Workarounds**: Native `fd` package eliminates need for `fd-find`/`fdfind` symlink
- **Documentation**: Updated architecture diagrams, package references, and examples to reflect openSUSE base layer
- **New Guide**: Added `docs/DOCKER-CLEANUP.md` for Docker and devcontainer cleanup procedures