### PR TITLE
Solves issue "#116 Add preflight validation for bind mount sources in devcontainer"

### DIFF
--- a/lib/dctl/test.sh
+++ b/lib/dctl/test.sh
@@ -82,6 +82,89 @@ cleanup_test_workspace_containers() {
   list_ws_containers | xargs -r docker rm -f
 }
 
+_resolve_local_env() {
+  local str="$1"
+  while [[ "$str" =~ \$\{localEnv:([A-Za-z_][A-Za-z0-9_]*)\} ]]; do
+    local var_name="${BASH_REMATCH[1]}"
+    local value="${!var_name-}"
+    local match="${BASH_REMATCH[0]}"
+    str="${str//"$match"/$value}"
+  done
+  printf '%s' "$str"
+}
+
+_extract_bind_mount_sources() {
+  local config_path="$1"
+  local stripped
+
+  stripped="$(_strip_jsonc_comments "$config_path")" || return 1
+
+  jq -r '
+    (.mounts // [])[]
+    | if type == "object" then
+        if (.type // "") == "bind" then ((.source // .src) // empty) else empty end
+      elif type == "string" then
+        if test("(^|,)type=bind(,|$)") then
+          (split(",")[] | select(test("^(source|src)=")) | sub("^(source|src)="; ""))
+        else empty end
+      else empty end
+  ' <<< "$stripped"
+}
+
+check_bind_mount_sources() {
+  local config_path="$1"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found; skipping bind mount source check"
+    return 0
+  fi
+
+  local sources
+  if ! sources="$(_extract_bind_mount_sources "$config_path")"; then
+    check_fail "Failed to parse bind mounts from $config_path"
+    return 1
+  fi
+
+  local -a missing_paths=()
+  local -a unresolved=()
+  local raw resolved
+  while IFS= read -r raw; do
+    [[ -n "$raw" ]] || continue
+    resolved="$(_resolve_local_env "$raw")"
+    if [[ -z "$resolved" ]]; then
+      unresolved+=("$raw")
+      continue
+    fi
+    [[ -e "$resolved" ]] || missing_paths+=("$resolved")
+  done <<< "$sources"
+
+  if [[ ${#missing_paths[@]} -eq 0 && ${#unresolved[@]} -eq 0 ]]; then
+    check_pass "Bind mount sources exist on host"
+    return 0
+  fi
+
+  check_fail "Missing bind mount source(s) on host"
+  local path
+  for path in "${missing_paths[@]}"; do
+    printf '    - %s\n' "$path" >&2
+  done
+  for path in "${unresolved[@]}"; do
+    printf '    - (unresolved) %s\n' "$path" >&2
+  done
+  if [[ ${#missing_paths[@]} -gt 0 ]]; then
+    printf '  Create the missing path(s) on the host before running devcontainer up, e.g.:\n' >&2
+    printf '    mkdir -p' >&2
+    for path in "${missing_paths[@]}"; do
+      printf ' %q' "$path"
+    done >&2
+    printf '\n' >&2
+  fi
+  if [[ ${#unresolved[@]} -gt 0 ]]; then
+    printf '  Set the referenced localEnv variable(s) on the host before running devcontainer up.\n' >&2
+  fi
+  return 1
+}
+
 build_workspace_image_if_managed() {
   local cfg="${1:-$(workspace_devcontainer_file)}"
   local image
@@ -160,12 +243,20 @@ cmd_test() {
       failures=$((failures + 1))
     fi
 
-    if devcontainer up --workspace-folder "$WORKSPACE_FOLDER" --config "$config_path"; then
-      check_pass "devcontainer up succeeded"
-      container_started=true
-    else
-      check_fail "devcontainer up failed"
+    local bind_sources_ok=true
+    if ! check_bind_mount_sources "$config_path"; then
       failures=$((failures + 1))
+      bind_sources_ok=false
+    fi
+
+    if [[ "$bind_sources_ok" == true ]]; then
+      if devcontainer up --workspace-folder "$WORKSPACE_FOLDER" --config "$config_path"; then
+        check_pass "devcontainer up succeeded"
+        container_started=true
+      else
+        check_fail "devcontainer up failed"
+        failures=$((failures + 1))
+      fi
     fi
 
     if [[ "$container_started" == true ]]; then

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -1468,3 +1468,149 @@ YAML
   [[ "$output" == *"Image status: external"* ]]
   assert_mock_not_called "CMD_IMAGE_BUILD_CALLED"
 }
+
+# --- Bind mount source preflight ---
+
+@test "_resolve_local_env substitutes localEnv vars and leaves literals alone" {
+  # shellcheck disable=SC2030
+  export HOME=/tmp/fixture-home
+  # shellcheck disable=SC2030
+  export USER=fixtureuser
+  # shellcheck disable=SC2016
+  [ "$(_resolve_local_env '${localEnv:HOME}/.config/x')" = "/tmp/fixture-home/.config/x" ]
+  # shellcheck disable=SC2016
+  [ "$(_resolve_local_env 'prefix-${localEnv:USER}-${localEnv:USER}')" = "prefix-fixtureuser-fixtureuser" ]
+  [ "$(_resolve_local_env '/plain/path')" = "/plain/path" ]
+}
+
+@test "check_bind_mount_sources passes when all bind sources exist" {
+  local cfg="${TEST_TMPDIR}/devcontainer.json"
+  local existing="${TEST_TMPDIR}/exists"
+  mkdir -p "$existing"
+  cat >"$cfg" <<EOF
+{
+  "mounts": [
+    {"source": "${existing}", "target": "/a", "type": "bind"},
+    {"source": "vol-x", "target": "/b", "type": "volume"}
+  ]
+}
+EOF
+  _check_names=()
+  _check_results=()
+  run check_bind_mount_sources "$cfg"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Bind mount sources exist on host"* ]]
+}
+
+@test "check_bind_mount_sources reports missing paths with mkdir hint" {
+  local cfg="${TEST_TMPDIR}/devcontainer.json"
+  local missing_dir="${TEST_TMPDIR}/missing-dir"
+  local missing_string="${TEST_TMPDIR}/missing-string"
+  cat >"$cfg" <<EOF
+{
+  "mounts": [
+    {"source": "${missing_dir}", "target": "/a", "type": "bind"},
+    "type=bind,source=${missing_string},target=/b"
+  ]
+}
+EOF
+  _check_names=()
+  _check_results=()
+  run check_bind_mount_sources "$cfg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Missing bind mount source(s) on host"* ]]
+  [[ "$output" == *"$missing_dir"* ]]
+  [[ "$output" == *"$missing_string"* ]]
+  [[ "$output" == *"mkdir -p"* ]]
+}
+
+@test "check_bind_mount_sources resolves localEnv and tolerates JSONC comments" {
+  # shellcheck disable=SC2030,SC2031
+  export HOME="${TEST_TMPDIR}/home"
+  mkdir -p "${HOME}/present"
+  local cfg="${TEST_TMPDIR}/devcontainer.json"
+  cat >"$cfg" <<'EOF'
+{
+  // leading JSONC comment
+  "mounts": [
+    {"source": "${localEnv:HOME}/present", "target": "/a", "type": "bind"},
+    {"source": "${localEnv:HOME}/absent", "target": "/b", "type": "bind"}
+  ]
+}
+EOF
+  _check_names=()
+  _check_results=()
+  run check_bind_mount_sources "$cfg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"${HOME}/absent"* ]]
+  [[ "$output" != *"${HOME}/present"$'\n'* ]]
+}
+
+@test "check_bind_mount_sources recognizes src= alias in string mounts" {
+  local cfg="${TEST_TMPDIR}/devcontainer.json"
+  local missing_src="${TEST_TMPDIR}/missing-src"
+  cat >"$cfg" <<EOF
+{
+  "mounts": [
+    "type=bind,src=${missing_src},target=/a"
+  ]
+}
+EOF
+  _check_names=()
+  _check_results=()
+  run check_bind_mount_sources "$cfg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"$missing_src"* ]]
+}
+
+@test "check_bind_mount_sources flags unresolved localEnv placeholders" {
+  unset DCTL_BIND_MISSING_VAR || true
+  local cfg="${TEST_TMPDIR}/devcontainer.json"
+  cat >"$cfg" <<'EOF'
+{
+  "mounts": [
+    {"source": "${localEnv:DCTL_BIND_MISSING_VAR}", "target": "/a", "type": "bind"}
+  ]
+}
+EOF
+  _check_names=()
+  _check_results=()
+  run check_bind_mount_sources "$cfg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"(unresolved)"* ]]
+  # shellcheck disable=SC2016
+  [[ "$output" == *'${localEnv:DCTL_BIND_MISSING_VAR}'* ]]
+}
+
+@test "check_bind_mount_sources fails on malformed JSON instead of silently passing" {
+  local cfg="${TEST_TMPDIR}/devcontainer.json"
+  printf '{ not valid json\n' >"$cfg"
+  _check_names=()
+  _check_results=()
+  run check_bind_mount_sources "$cfg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Failed to parse bind mounts"* ]]
+}
+
+@test "cmd_test skips devcontainer up when a bind mount source is missing" {
+  create_user_image_fixture python-dev
+  mkdir -p "$(workspace_devcontainer_dir)"
+  local missing="${TEST_TMPDIR}/never-created"
+  cat >"$(workspace_devcontainer_file)" <<EOF
+{
+  "image": "devimg/python-dev:latest",
+  "mounts": [
+    {"source": "${missing}", "target": "/mnt/x", "type": "bind"}
+  ]
+}
+EOF
+  enable_mocks
+  create_mock docker 0 "container123"
+  create_mock devcontainer 0 ""
+
+  run cmd_test
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Missing bind mount source(s) on host"* ]]
+  [[ "$output" == *"$missing"* ]]
+  assert_mock_not_called "devcontainer up"
+}


### PR DESCRIPTION
Closes #116

## Summary

Adds preflight validation for bind mount sources in devcontainer.json before attempting to start containers. This catches missing sources and unresolved environment variables early, providing developers with actionable error messages (including mkdir hints) instead of letting the devcontainer up command fail with unclear errors.

## Key Changes

- **`_resolve_local_env()`**: Substitutes `${localEnv:VAR}` placeholders in mount paths using environment variables
- **`_extract_bind_mount_sources()`**: Parses bind mounts from devcontainer configs, supporting both object and string mount formats, with JSONC comment handling
- **`check_bind_mount_sources()`**: Validates that all extracted bind mount sources exist on the host; reports missing paths with mkdir suggestions and flags unresolved environment variables
- **Integration into `cmd_test()`**: Validation runs before devcontainer up; if sources are missing, the container startup is skipped and failures are reported
- **Comprehensive test coverage**: Tests cover existing paths, missing paths, JSONC comments, localEnv resolution, src= aliases, unresolved placeholders, and malformed JSON scenarios