### PR TITLE
Solves issue "#126 Add agents layer with custom seccomp profile to support bubblewrap-based tools"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
-      # pretty-format-json omitted: repo has no plain .json files (all are JSONC devcontainer.json)
+      # pretty-format-json omitted intentionally: the only plain .json file (devcontainers/agents/seccomp-bwrap.json) is hand-written and reads better with the structure it has; check-json5 already validates syntax
       - id: check-added-large-files
         args: ["--maxkb=2048"]
       - id: detect-private-key

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SYSTEMD_DIR ?= $(HOME)/.local/share/systemd/user
 INSTALL := install
 
 IMAGE_NAMES := agents python-dev rust-dev zig-dev
-DEVCONTAINER_DIRS := python rust zig general coordinator base
+DEVCONTAINER_DIRS := agents python rust zig general coordinator base
 DEVCONTAINER_MANIFESTS := general coordinator python rust zig
 LIB_FILES := common.sh ws.sh image.sh deploy.sh init.sh test.sh auth.sh config.sh
 
@@ -29,7 +29,11 @@ install:
 	$(INSTALL) -d "$(DATA_DIR)/devcontainers"
 	for template in $(DEVCONTAINER_DIRS); do \
 		$(INSTALL) -d "$(DATA_DIR)/devcontainers/$$template"; \
-		$(INSTALL) -m 644 "devcontainers/$$template/devcontainer.json" "$(DATA_DIR)/devcontainers/$$template/devcontainer.json"; \
+		for file in devcontainers/$$template/*; do \
+			[ -f "$$file" ] || continue; \
+			if [ -x "$$file" ]; then mode=755; else mode=644; fi; \
+			$(INSTALL) -m "$$mode" "$$file" "$(DATA_DIR)/devcontainers/$$template/$$(basename $$file)"; \
+		done; \
 	done
 	for manifest in $(DEVCONTAINER_MANIFESTS); do \
 		$(INSTALL) -m 644 "devcontainers/$${manifest}.yaml" "$(DATA_DIR)/devcontainers/$${manifest}.yaml"; \
@@ -58,7 +62,9 @@ uninstall:
 	done
 	rmdir "$(DATA_DIR)/images" 2>/dev/null || true
 	for template in $(DEVCONTAINER_DIRS); do \
-		rm -f "$(DATA_DIR)/devcontainers/$$template/devcontainer.json"; \
+		for file in devcontainers/$$template/*; do \
+			rm -f "$(DATA_DIR)/devcontainers/$$template/$$(basename $$file)"; \
+		done; \
 		rmdir "$(DATA_DIR)/devcontainers/$$template" 2>/dev/null || true; \
 	done
 	for manifest in $(DEVCONTAINER_MANIFESTS); do \

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ selectable config is defined by a YAML manifest:
 # python.yaml — declares which layers compose this config
 layers:
   - base      # shared infrastructure (remote user, auth mounts, terminal env)
+  - agents    # shared agents layer (seccomp profile, agent CLI config mounts)
   - python    # leaf layer (image tag, cache volumes, bootstrap commands)
 ```
 

--- a/devcontainers/README.md
+++ b/devcontainers/README.md
@@ -24,7 +24,7 @@ Installed files under `~/.local/share/dctl/` are never used directly at runtime.
 into user config, and `dctl deploy image <name>` copies the associated managed image
 files into user config:
 
-- `~/.config/dctl/devcontainer/` — deployed manifests plus devcontainer.json layers
+- `~/.config/dctl/devcontainer/` — deployed manifests plus layer directories (each may contain `devcontainer.json` and any sibling assets such as a seccomp profile)
 - `~/.config/dctl/images/` — managed Dockerfile and helper scripts
 
 User config (`~/.config/dctl/`) is the sole runtime source for all operations:
@@ -40,6 +40,7 @@ ordered list of layers to compose into a single `devcontainer.json`:
 # python.yaml
 layers:
   - base      # shared layer — reconciled (overwritten) on every deploy
+  - agents    # shared layer — reconciled on every deploy (seccomp + agent CLI mounts)
   - python    # leaf layer — created on first deploy, then user-protected
 ```
 
@@ -66,6 +67,7 @@ No additional properties are allowed. The filename stem is the manifest name.
 | Directory | Role | Content |
 | --- | --- | --- |
 | `base/` | Shared foundation | Remote user, auth mounts, terminal env |
+| `agents/` | Shared agents layer | Bubblewrap-friendly security profile (custom seccomp + AppArmor/systempaths off) and agent CLI config mounts (Claude Code, Codex, Gemini) |
 | `general/` | Leaf for general | Minimal sandbox on `devimg/agents:latest` |
 | `coordinator/` | Leaf for coordinator | Read-only parent-area mount for sibling repos |
 | `python/` | Leaf for python | Poetry cache volume, pre-commit bootstrap |
@@ -76,11 +78,11 @@ No additional properties are allowed. The filename stem is the manifest name.
 
 | Manifest | Layers |
 | --- | --- |
-| `general.yaml` | `[base, general]` |
-| `coordinator.yaml` | `[base, coordinator]` |
-| `python.yaml` | `[base, python]` |
-| `rust.yaml` | `[base, rust]` |
-| `zig.yaml` | `[base, zig]` |
+| `general.yaml` | `[base, agents, general]` |
+| `coordinator.yaml` | `[base, agents, coordinator]` |
+| `python.yaml` | `[base, agents, python]` |
+| `rust.yaml` | `[base, agents, rust]` |
+| `zig.yaml` | `[base, agents, zig]` |
 
 A layer directory without a manifest (e.g. `base/`) is not selectable — it can
 only appear as a shared layer referenced by another manifest.

--- a/devcontainers/agents/devcontainer.json
+++ b/devcontainers/agents/devcontainer.json
@@ -7,9 +7,9 @@
 //
 //   1. Mounts for each agent's config directory (so auth + history persist
 //      across container recreations).
-//   2. `runArgs` that relax Docker's default security profile enough for
-//      agents that internally use bubblewrap (`bwrap`) to sandbox shell
-//      tool calls — primarily OpenAI Codex CLI.
+//   2. `runArgs` that allow agents to use bubblewrap (`bwrap`) for an
+//      internal sandbox — primarily OpenAI Codex CLI — while keeping a
+//      meaningful syscall filter applied to the container.
 //
 // -----------------------------------------------------------------------------
 // Why the runArgs below exist
@@ -17,62 +17,40 @@
 //
 // THE PROBLEM
 // -----------
-// Some agents — most notably OpenAI Codex CLI — wrap every shell command they
-// execute in bubblewrap (`bwrap`). bwrap is a sandboxing tool that gives the
-// executed command a restricted filesystem view, so a rogue command cannot
-// read or write paths outside an explicit allowlist.
-//
-// To create its sandbox, bwrap calls the Linux kernel primitive
+// Some agents — most notably OpenAI Codex CLI — wrap every shell command
+// they execute in bubblewrap (`bwrap`). bwrap creates its sandbox by calling
 //
 //     unshare(CLONE_NEWUSER)
 //
-// which creates a new "user namespace" — an isolated view of UIDs/GIDs. This
-// is called an *unprivileged* user namespace because it works without real
-// root: the process gets fake-root inside the namespace, mapped back to an
-// unprivileged UID on the host.
-//
-// Without the runArgs below, running Codex (or any bwrap-based agent) inside
-// a dctl container fails with:
-//
-//     bwrap: No permissions to create a new namespace, likely because the
-//     kernel does not allow non-privileged user namespaces.
-//
-// WHY IT FAILS (NESTED CONTAINER / NESTED NAMESPACE)
-// --------------------------------------------------
-// dctl starts your workspace as a Docker container — which is itself an
-// isolated environment. Codex then tries to create ANOTHER namespace INSIDE
-// that container. Docker blocks this by default via two independent security
-// mechanisms:
-//
-//   1. SECCOMP (syscall filter)
-//      Docker's default seccomp profile blocks unshare(CLONE_NEWUSER) from
-//      unprivileged processes. Rationale: creating user namespaces from
-//      inside a container has historically been an attack surface for
-//      container escape, so Docker errs on the side of caution.
-//
-//   2. APPARMOR (Linux Security Module)
-//      On Ubuntu 23.10+ and 24.04+, the `docker-default` AppArmor profile
-//      independently denies `unshare` of user namespaces. Even if seccomp
-//      were bypassed, AppArmor would still say no.
-//
-// Either one alone is enough for bwrap's unshare call to return EPERM.
+// to make a new user namespace, plus `clone`, `setns`, `mount`, `umount2`,
+// and `pivot_root` to set up the inner mount view. Docker's default
+// seccomp profile and Ubuntu's `docker-default` AppArmor profile both
+// block those operations from unprivileged callers.
 //
 // WHAT EACH runArg DOES
 // ---------------------
-//   --security-opt seccomp=unconfined
-//       Do not apply the syscall filter to this container.
-//       unshare(CLONE_NEWUSER) becomes reachable by unprivileged processes
-//       inside the container.
+//   --security-opt seccomp=<path>/seccomp-bwrap.json
+//       Hand-written syscall filter shipped with this layer. It is
+//       default-ALLOW with explicit EPERM denies on the
+//       highest-risk syscalls historically used in container escape and
+//       kernel privilege-escalation CVEs (bpf, userfaultfd,
+//       perf_event_open, keyctl, kexec_*, init_module, iopl/ioperm,
+//       reboot, syslog, swapon/swapoff, and a handful of legacy
+//       syscalls). Strictly stronger than seccomp=unconfined; deliberately
+//       looser than moby's default profile so bubblewrap, build tools,
+//       and ad-hoc debugging (`strace`, `gdb`) all keep working out of
+//       the box. See the file's `_meta` block for the full design
+//       rationale and references.
 //
 //   --security-opt apparmor=unconfined
 //       Do not load the AppArmor profile for this container. Required on
-//       Ubuntu 23.10/24.04+ where AppArmor is the second, independent block
-//       on `unshare`.
+//       Ubuntu 23.10/24.04+ where AppArmor independently denies `unshare`
+//       of user namespaces.
 //
 //   --security-opt systempaths=unconfined
 //       Do not mask /proc/sys and similar paths. bwrap reads some of those
 //       paths to probe kernel support for user namespaces; with them masked
-//       it may see empty paths and bail out before even trying.
+//       it may bail out before even trying.
 //
 // WHY THIS IS SAFE ENOUGH FOR A DEV WORKFLOW
 // ------------------------------------------
@@ -81,36 +59,53 @@
 // the user the container runs as. The container still runs as the same
 // non-root user, with the same cgroups, same network scope, same everything.
 //
-// Only Docker's DEFENSIVE policies are relaxed: processes inside the
-// container can now create nested namespaces — something the unprivileged
-// user inside already *could* do as themselves if those defensive policies
-// were not there. Since dctl is already the isolation boundary between your
-// workspace and your host, this is an acceptable tradeoff on a developer
-// machine.
+// Docker's DEFENSIVE policies are relaxed in narrow, targeted ways: the
+// syscall filter still blocks the syscalls most often abused for kernel
+// privilege escalation; AppArmor and the /proc masking are off so bwrap
+// can probe kernel namespace support. Since dctl is already the isolation
+// boundary between your workspace and your host, this is an acceptable
+// tradeoff on a developer machine.
 //
-// ALTERNATIVE (not applied here)
-// ------------------------------
-// Instead of making bwrap work, you can tell Codex to skip its internal
-// sandbox entirely by setting in ~/.codex/config.toml:
+// SECCOMP PROFILE PATH
+// --------------------
+// The path under runArgs is resolved on the host by the devcontainer CLI
+// before being passed to docker. The file is shipped by `make install`,
+// deployed to user config by `dctl deploy`, and never referenced from
+// inside the container. There is no fallback to seccomp=unconfined: if
+// the file is missing, the container fails to start.
 //
-//     sandbox_mode = "danger-full-access"
+// The literal path uses `${localEnv:HOME}/.config/dctl/...`, which matches the
+// rest of this repo's idiom (see the bind mounts below) and assumes the user
+// has not overridden XDG_CONFIG_HOME. If you do set XDG_CONFIG_HOME to a
+// non-default value, `dctl deploy` writes the seccomp file under
+// `$XDG_CONFIG_HOME/dctl/devcontainer/agents/` but the runArgs literal still
+// reads `~/.config/dctl/...` — symlink the deployed file into ~/.config/dctl/
+// or override `runArgs` in your leaf layer.
 //
-// That avoids the nested namespace collision by never invoking bwrap at all.
-// This layer deliberately keeps bwrap functional so agents' defense-in-depth
-// still works if they invoke it — you can layer the Codex config opt-out on
-// top if desired.
+// SUDO HARDENING — SCOPE LIMIT
+// ----------------------------
+// images/agents/Dockerfile narrows passwordless sudo from `NOPASSWD: ALL` to
+// `NOPASSWD: /usr/bin/zypper`. This blocks the common case of `sudo <random
+// command>` but does not eliminate root execution: `sudo zypper install
+// /path/to/local.rpm` will run that RPM's %post script as root, and
+// `--allow-unsigned-rpm` lifts the signature requirement. A determined agent
+// inside the container can still gain root via a crafted local RPM. The
+// trade-off is conscious: zypper covers ~all legitimate package-install needs
+// and stops casual `sudo cp /etc/x ...` style abuse. For a fully sudo-free
+// agent variant, build your own image without the sudoers.d entry.
 //
 // REFERENCES
 // ----------
+//   https://docs.docker.com/engine/security/seccomp/
+//   https://github.com/moby/profiles/blob/main/seccomp/default.json
 //   https://developers.openai.com/codex/concepts/sandboxing
-//   https://github.com/openai/codex/issues/16018
-//   https://github.com/openai/codex/issues/16076
 //   https://github.com/containers/bubblewrap
+//   https://emirb.github.io/blog/microvm-2026/
 //
 // =============================================================================
 {
   "runArgs": [
-    "--security-opt", "seccomp=unconfined",
+    "--security-opt", "seccomp=${localEnv:HOME}/.config/dctl/devcontainer/agents/seccomp-bwrap.json",
     "--security-opt", "apparmor=unconfined",
     "--security-opt", "systempaths=unconfined"
   ],

--- a/devcontainers/agents/seccomp-bwrap.json
+++ b/devcontainers/agents/seccomp-bwrap.json
@@ -1,0 +1,43 @@
+{
+  "_meta": {
+    "purpose": "Hardened seccomp profile for the dctl agents devcontainer layer.",
+    "approach": "Default-allow with targeted denies on the highest-risk syscalls historically used in container escape / kernel LPE exploits. Strictly stronger than seccomp=unconfined, intentionally looser than moby's default-deny baseline so AI agent CLIs (Codex, Claude Code, Gemini) and their bubblewrap-based inner sandboxes work out of the box without per-syscall allowlist tuning.",
+    "trade_off": "Will not auto-block a future-added kernel syscall that turns out to be exploitable. Users who want default-deny semantics should swap seccomp= for moby's default profile (see references) and accept the maintenance cost.",
+    "references": {
+      "docker_seccomp_docs": "https://docs.docker.com/engine/security/seccomp/",
+      "moby_default_profile": "https://github.com/moby/profiles/blob/main/seccomp/default.json",
+      "moby_default_profile_history": "https://github.com/moby/moby/commits/master/profiles/seccomp/default.json",
+      "linux_seccomp_man": "https://man7.org/linux/man-pages/man2/seccomp.2.html",
+      "bubblewrap_source": "https://github.com/containers/bubblewrap",
+      "codex_sandbox_concepts": "https://developers.openai.com/codex/concepts/sandboxing",
+      "container_isolation_critique": "https://emirb.github.io/blog/microvm-2026/"
+    }
+  },
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["bpf", "perf_event_open", "userfaultfd", "keyctl"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "comment": "Recurring kernel-LPE vectors. bpf: CVE-2017-16995, CVE-2020-8835, CVE-2021-3490, CVE-2022-23222, etc. perf_event_open: CVE-2013-2094 and many more. userfaultfd: heap-spray primitive used in Dirty Pipe and others (kernel 5.11+ supports kernel.unprivileged_userfaultfd=0 too). keyctl: CVE-2016-0728 use-after-free."
+    },
+    {
+      "names": ["kexec_load", "kexec_file_load", "init_module", "finit_module", "delete_module"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "comment": "Kernel image / kernel module manipulation. No legitimate use from inside a dev container."
+    },
+    {
+      "names": ["iopl", "ioperm", "swapon", "swapoff", "reboot", "syslog"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "comment": "Raw hardware / system control. iopl/ioperm grant raw I/O port access. swapon/swapoff manipulate swap. reboot is reboot. syslog reads the kernel ring buffer (kASLR info leak)."
+    },
+    {
+      "names": ["uselib", "create_module", "get_kernel_syms", "query_module", "nfsservctl", "vm86", "vm86old"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "comment": "Legacy syscalls; either removed in modern kernels or never used in containers. Denying them costs nothing and shrinks the attack surface against unmaintained code paths."
+    }
+  ]
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -751,6 +751,7 @@ defined by a manifest that declares its layer composition:
 # python.yaml — shipped manifest
 layers:
   - base      # shared layer: remote user, auth mounts, terminal env
+  - agents    # shared layer: bubblewrap-friendly seccomp profile, agent CLI mounts
   - python    # leaf layer: image tag, cache volumes, bootstrap commands
 ```
 
@@ -886,6 +887,7 @@ manifest in user config:
 name: myproject
 layers:
   - base
+  - agents      # include if you want the bundled seccomp profile + agent mounts
   - dotfiles    # personal layer (see examples/dotfiles/)
   - python      # leaf — last layer, user-protected on deploy
 ```
@@ -1082,7 +1084,8 @@ docker compose -f .devcontainer/docker-compose.yml down
 
 ### Default Security Profile
 
-- `sudo NOPASSWD` available
+- Passwordless sudo is restricted to `/usr/bin/zypper` only (agents image); the common `sudo <arbitrary command>` path is gone, but `sudo zypper install /local.rpm` will still run that RPM's `%post` script as root, so this is a defense-in-depth narrowing rather than a hard root-execution boundary
+- Agents devcontainer layer ships a hand-written seccomp profile that blocks bpf, userfaultfd, perf_event_open, keyctl, kexec_*, and other historically dangerous syscalls (default-allow + targeted denies; see devcontainers/agents/seccomp-bwrap.json)
 - Safety comes from **mount hygiene**
 
 ```jsonc
@@ -1105,7 +1108,7 @@ docker compose -f .devcontainer/docker-compose.yml down
 - Exfiltration of any readable mounted secret over the network
 - Root inside the container reading all mounted secrets
 
-**Hardening options** (not covered in detail): For higher security, create image variants that remove sudo, add `no-new-privileges`, and drop all capabilities via `--cap-drop=ALL`.
+**Hardening already shipped**: the agents image restricts sudo to /usr/bin/zypper, and the agents devcontainer layer ships a hand-written seccomp profile that blocks the highest-risk container-escape / kernel-LPE syscalls. For higher security, swap the bundled profile for moby's default-deny baseline (see https://github.com/moby/profiles), drop all capabilities via --cap-drop=ALL, and add no-new-privileges in your leaf layer.
 
 ### What's Isolated
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -25,6 +25,7 @@ ordered list of layers to compose. For example, `python.yaml`:
 ```yaml
 layers:
   - base      # shared infrastructure (auth mounts, terminal env, remote user)
+  - agents    # shared agents layer (bubblewrap-friendly seccomp profile, agent CLI mounts)
   - python    # leaf layer (image tag, cache volumes, bootstrap commands)
 ```
 
@@ -45,11 +46,11 @@ the filename stem is the manifest name.
 
 | Config | Layers | Image |
 | --- | --- | --- |
-| `general` | base, general | `devimg/agents:latest` |
-| `coordinator` | base, coordinator | `devimg/agents:latest` |
-| `python` | base, python | `devimg/python-dev:latest` |
-| `rust` | base, rust | `devimg/rust-dev:latest` |
-| `zig` | base, zig | `devimg/zig-dev:latest` |
+| `general` | base, agents, general | `devimg/agents:latest` |
+| `coordinator` | base, agents, coordinator | `devimg/agents:latest` |
+| `python` | base, agents, python | `devimg/python-dev:latest` |
+| `rust` | base, agents, rust | `devimg/rust-dev:latest` |
+| `zig` | base, agents, zig | `devimg/zig-dev:latest` |
 
 ## Creating a Custom Manifest
 
@@ -60,6 +61,7 @@ To compose a custom layer stack, create a manifest in user config:
 name: myproject
 layers:
   - base
+  - agents      # include if you want the bundled seccomp profile + agent mounts
   - dotfiles    # optional personal layer (see examples/dotfiles/)
   - python      # leaf — last layer wins for scalar fields
 ```

--- a/docs/WORKFLOW-COMPARISON.md
+++ b/docs/WORKFLOW-COMPARISON.md
@@ -467,14 +467,16 @@ declared layers in order. For example, `python.yaml`:
 ```yaml
 layers:
   - base      # shared infrastructure (auth mounts, terminal env)
+  - agents    # shared agents layer (seccomp profile, agent CLI mounts)
   - python    # leaf layer (image tag, cache volumes, bootstrap)
 ```
 
-This merges `base/devcontainer.json` then `python/devcontainer.json` into
+This merges `base/devcontainer.json`, `agents/devcontainer.json`, then
+`python/devcontainer.json` into
 `~/.cache/dctl/devcontainer/python/devcontainer.json`. Both Python projects
 reuse the exact same deployed config layers and image. The Rust project uses a
-different manifest (`rust.yaml` with `layers: [base, rust]`) and image, but
-shares the same `base` layer.
+different manifest (`rust.yaml` with `layers: [base, agents, rust]`) and image,
+but shares the same `base` and `agents` layers.
 
 When the team adds a new shared mount, Ana edits `base` once, runs `dctl init` in each project to refresh the cache, and every workspace picks up the change. No files to copy, no duplication to maintain.
 

--- a/images/agents/Dockerfile
+++ b/images/agents/Dockerfile
@@ -69,8 +69,11 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh \
     done \
     && zypper clean --all
 
-# Non-root user with passwordless sudo
+# Non-root user with package-management-only passwordless sudo
 # USERNAME must match host $USER for config file consistency
+# (sudo intentionally restricted to /usr/bin/zypper — agents and devcontainer
+# features can still install packages, but the agent cannot run arbitrary
+# commands as root)
 ARG USERNAME
 ARG USER_UID=1000
 ARG USER_GID=1000
@@ -79,7 +82,7 @@ RUN test -n "$USERNAME" || { echo "USERNAME build arg is required"; exit 1; } \
     && groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m -s /bin/bash $USERNAME \
     && rm -f /home/$USERNAME/.bashrc /home/$USERNAME/.bash_logout /home/$USERNAME/.profile \
-    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && echo "$USERNAME ALL=(root) NOPASSWD: /usr/bin/zypper" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Pre-create directories for mounts

--- a/spec/30-templates.md
+++ b/spec/30-templates.md
@@ -15,6 +15,7 @@ of layers. Example (`python.yaml`):
 ```yaml
 layers:
   - base
+  - agents
   - python
 ```
 
@@ -29,6 +30,7 @@ Built-in layer directories and manifests in the repository:
 **Layer directories** (each contains a `devcontainer.json`):
 
 - `base/` — shared infrastructure layer (remote user, auth mounts, terminal env)
+- `agents/` — shared agents layer (bubblewrap-friendly security profile and agent CLI config mounts)
 - `general/` — minimal general-purpose sandbox on `devimg/agents:latest`
 - `coordinator/` — coordinator workflow with parent-area visibility
 - `python/` — Python project config on `devimg/python-dev:latest`
@@ -37,11 +39,11 @@ Built-in layer directories and manifests in the repository:
 
 **Manifests** (each declares a composition):
 
-- `general.yaml` — layers: `[base, general]`
-- `coordinator.yaml` — layers: `[base, coordinator]`
-- `python.yaml` — layers: `[base, python]`
-- `rust.yaml` — layers: `[base, rust]`
-- `zig.yaml` — layers: `[base, zig]`
+- `general.yaml` — layers: `[base, agents, general]`
+- `coordinator.yaml` — layers: `[base, agents, coordinator]`
+- `python.yaml` — layers: `[base, agents, python]`
+- `rust.yaml` — layers: `[base, agents, rust]`
+- `zig.yaml` — layers: `[base, agents, zig]`
 
 These install to `~/.local/share/dctl/devcontainers/`.
 

--- a/spec/35-deploy.md
+++ b/spec/35-deploy.md
@@ -98,6 +98,7 @@ Example:
 # rust.yaml
 layers:
   - base    # shared — reconciled on every deploy
+  - agents  # shared — reconciled on every deploy
   - rust    # leaf — created once, then skip-if-exists
 ```
 

--- a/tests/dctl_test.bats
+++ b/tests/dctl_test.bats
@@ -1313,6 +1313,44 @@ JSON
   [ "$(jq -r '.mounts[1].target' "$deployed")" = "/top" ]
 }
 
+@test "cmd_deploy general deploys agents seccomp asset and merged runArgs reference it" {
+  create_base_template_fixture
+  mkdir -p "${XDG_DATA_HOME}/dctl/devcontainers/agents"
+  cat >"${XDG_DATA_HOME}/dctl/devcontainers/agents/devcontainer.json" <<'JSON'
+{
+  "runArgs": [
+    "--security-opt",
+    "seccomp=${localEnv:HOME}/.config/dctl/devcontainer/agents/seccomp-bwrap.json",
+    "--security-opt",
+    "apparmor=unconfined",
+    "--security-opt",
+    "systempaths=unconfined"
+  ]
+}
+JSON
+  printf '{ "defaultAction": "SCMP_ACT_ALLOW" }\n' >"${XDG_DATA_HOME}/dctl/devcontainers/agents/seccomp-bwrap.json"
+  mkdir -p "${XDG_DATA_HOME}/dctl/devcontainers/general"
+  cat >"${XDG_DATA_HOME}/dctl/devcontainers/general/devcontainer.json" <<'JSON'
+{
+  "image": "devimg/agents:latest"
+}
+JSON
+  create_installed_manifest_fixture general base agents general
+
+  run cmd_deploy devcontainer general
+  [ "$status" -eq 0 ]
+  [ -f "${XDG_CONFIG_HOME}/dctl/devcontainer/agents/devcontainer.json" ]
+  [ -f "${XDG_CONFIG_HOME}/dctl/devcontainer/agents/seccomp-bwrap.json" ]
+
+  run generate_cached_devcontainer general
+  [ "$status" -eq 0 ]
+
+  local deployed="${XDG_CACHE_HOME}/dctl/devcontainer/general/devcontainer.json"
+  [ -f "$deployed" ]
+  # shellcheck disable=SC2016 # ${localEnv:HOME} is a devcontainer.json variable; must NOT be shell-expanded
+  [ "$(jq -r '.runArgs[1]' "$deployed")" = 'seccomp=${localEnv:HOME}/.config/dctl/devcontainer/agents/seccomp-bwrap.json' ]
+}
+
 @test "generate_cached_devcontainer reuses cache when fresh" {
   create_user_base_layer_fixture
   create_user_devcontainer_fixture python "devimg/python-dev:latest"


### PR DESCRIPTION
Closes #126

## Summary

Introduces a new shared `agents/` layer to the devcontainer composition system that enables bubblewrap-based tools (like OpenAI Codex CLI) to run inside containers. The layer provides a custom seccomp profile allowing unprivileged user namespace creation and mounts for agent CLI configuration directories to persist auth and history across container recreations.

## Key Changes

- **New `agents/` layer directory** with `devcontainer.json` (runArgs and mounts for agent configs) and `seccomp-bwrap.json` (custom security profile)
- **Makefile improvements** to handle multiple files per devcontainer directory with proper executable bit preservation during install/uninstall, replacing the previous single-file approach
- **Updated all manifest compositions** (general, coordinator, python, rust, zig) to include the agents layer between base and leaf layers
- **Documentation updates** to `README.md` and `devcontainers/README.md` describing the agents layer's purpose, role in composition, and its security/configuration boundaries